### PR TITLE
Development (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## CHANGELOG
 
+### Changelog - 2023.05.04 `v0.3.0`
+
+- **Preparation for figure integration**
+  - **`NEW`** Added `marginfig` commands for placing figures in margins nicely (including associated geometry changes)
+  - Completely reworked `APG-68`, `A-A Weapons`, and `PROCEDURES` chapters
+    - added placeholder figures (boxes) including new `marginfigs`
+    - better clarity and legibility
+    - began adding `tikz`-based diagrams (starting for BVR diagrams)
+- **Remove/comment-out work-in-progress chapter contents**
+- **Updated table-of-contents (TOC)**
+  - Moved main TOC into own `.tex` file
+  - **`NEW`** Added/moved disclaimer and explanation of mandatory step, notebox, and warningbox symbology into TOC file
+  - Improved per-chapter TOCs by switching to `etoc` package
+    - better compatibility with `titlesec` package
+    - reduced number of auxiliary files
+- **Further improvements to `cls` files**
+  - Changed geometry default to non-print A5 sized paper
+  - Improved hatching algorithm to automatically account for paper width
+  - **`NEW`** Section and chapter marks in header are now hyperlinks
+  - **`NEW`** Wider `crown quatro` paper size, currently non-print only
+  - Removed `Helvet` font
+
 ### Changelog - 2023.01.14 `v0.2.0`
 
 - **Complete Rewrite OF `TechCheck` Class Architecture:** many commands/environments were moved into two new `.sty` files (packages)

--- a/TechCheck.cls
+++ b/TechCheck.cls
@@ -321,19 +321,19 @@
 % APPLY PAGE GEOMETRY
 %-----------------------------------------------------------------
 \geometry{
-  paperheight=\TC@paperh,
-  paperwidth=\TC@paperw,
-  margin=1mm,
-  top=\TC@topmar,
-  bottom=\TC@botmar,
-  headsep=5mm,
-  headheight=5mm,
-  footskip=\TC@footmar,
-  inner=\TC@inmar,
-  outer=\TC@outmar,
-  marginparwidth=0mm,
-  marginparsep=0mm,
-  centering,
+	paperheight=\TC@paperh,
+	paperwidth=\TC@paperw,
+	margin=1mm,
+	top=\TC@topmar,
+	bottom=\TC@botmar,
+	headsep=5mm,
+	headheight=5mm,
+	footskip=\TC@footmar,
+	inner=\TC@inmar,
+	outer=\TC@outmar,
+	marginparwidth=0mm,
+	marginparsep=0mm,
+	centering,
 }
 
 %-----------------------------------------------------------------


### PR DESCRIPTION
* v0.2.0 (#17) (#38)

* Dev/formatting (#7)

* Dev/format/tcolorbox like enumitem (#4)

* add tcolorbox enumitem

* update to use new tcolorenumitem

* Dev/format/tcolorbox like enumitem (#5)

* add tcolorbox enumitem

* update to use new tcolorenumitem

* reduced global enumitem indent

* changed enumitem spacing to tcolor specific

* Dev/format/pkg files (#6)

* moved hatching cmds to own file

* moved enumitem envs to own file

* removed hatching/enumitem

* removed enumitem resizing, now tcolor gap (#8)

* Dev/class/square tabs (#9)

* moved atbegshi to techhatch

* setup tikz style for future ifelse options

* improved segmentation of tcolorenumitems

* added xkeyval pkg

* added tcolor counter, removed old short/long cmds

* rename to fix case issue

* rename back to fix case issue

* rename to fix case issue

* rename back to fix case issue

* renamed to reflect tab cmds

* removec to fix naming

* readd as new file

* reflect hatchtabs name change

* added missing extension

* bugfix - print toggle was never false

* fixed option passing typo

* added etoolbox for toggles

* moved rounding parameters

* added toggle for rounding

* added toggle for square tabs

* squaretab toggle false by default

* made squaretabs an option

* made round an option

* moved custom pkg loading

* added 'round' if 'print'

* Dev/class/better options (#10)

* fixed illogical pkg loading

* indentation consistency

* factored out low level rounding commands

* added option for thumb tab indentation

* renamed tab indent toggle for consistency

* added option: automatic thumbback

* replaced cm with mm

* added descriptions of commands/options

* swapped to xkeyval booleans

* added bool for thumbnar indent (narrowing)

* added error handling

* added new options to pass to hatchtabs

* added better option passing for `print` option

* added lengths to pkg as options

* added THT length option passing

* fixed copyright dates, remoed deprecated pkg

* cleanup code style

* moved hatch option to techhatchtabs

* options processed in order, style fixes

* moved 'manthumbnar' to techhatchtabs

* decapitalized '\hatch'

* Dev/finish a a radar content (#12)

* test crm fig changes

* updated to new diagram, changed cm->mm

* added ACM subsec

* added/moved STT subsec

* wording change for clarity

* [BUGFIX] corrected `slewable` title

* Dev/class/titlepage commandify (#13)

* added commands for titlepage

* changed lenghts to private 'TC@'

* updated dates

* added better option passing to techhatchtabs (#15)

* changed to a5 paper

* updated changelog

* [FIX] minor whitespace fix

* update changelog