### PR TITLE
Refactor/better enumitem syntax

### DIFF
--- a/src/chapters/proc_basic/inflight.tex
+++ b/src/chapters/proc_basic/inflight.tex
@@ -5,7 +5,7 @@
 \subsection{AIR-TO-AIR REFUELING}
 
 \begin{checklistenumerate}
-    \blueitem{Safe Aircraft}{
+    \blueitem[Safe Aircraft]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -58,8 +58,8 @@
         \item \textbf{Master Arm} \dotfill \textbf{OFF}
         \item \textbf{Laser Arm} \dotfill \textbf{OFF}
         \item \textbf{RF Switch} \dotfill \textbf{SILENT}
-    \end{enumerate}}
-    \blueitem{Configure for Refueling}{
+    \end{enumerate}
+    \blueitem[Configure for Refueling]
     \begin{enumerate}
         \item \textbf{AIR REFUEL Switch}\cbstart \dotfill \textbf{Open}
         \item \textbf{AR Status Light} \dotfill \textbf{Verify RDY}\cbend
@@ -72,8 +72,8 @@
     
     \begin{enumerate}[start=6]
         \item \textbf{DED Data/PFL Switch} \dotfill \textbf{DED Data} 
-    \end{enumerate}}
-    \blueitem{Refuel\cbstart}{
+    \end{enumerate}
+    \blueitem[Refuel\cbstart]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -114,8 +114,8 @@
         \item \textbf{AR/NWS Light} illuminates to indicate contact
         \item Reference director lights to maintain position within boom limits, reference \cref{fig:proc_basic:aarefueling:lights}
         \item Monitor refueling progress on DED/HUD
-    \end{itemize}}
-    \blueitem{Post-Refueling}{
+    \end{itemize}
+    \blueitem[Post-Refueling]
     \begin{enumerate}
         \item \textbf{A/R DISC Button} \dotfill \textbf{Press}
         \item \textbf{AIR REFUEL Switch} \dotfill \textbf{Close}\cbend
@@ -123,13 +123,13 @@
         \item \textbf{FUEL QTY} \dotfill \textbf{Check}
         \item \textbf{AR Status Light} \dotfill \textbf{Verify Off}
         \item \textbf{Exterior Lights} \dotfill \textbf{As required}
-    \end{enumerate}}
-    \blueitem{Rearm Aircraft}{
+    \end{enumerate}
+    \blueitem[Rearm Aircraft]
     \begin{enumerate}
         \item \textbf{RF Switch} \dotfill \textbf{As Required}
         \item \textbf{Laser Arm} \dotfill \textbf{As Required}
         \item \textbf{Master Arm} \dotfill \textbf{As Required}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/proc_basic/startup.tex
+++ b/src/chapters/proc_basic/startup.tex
@@ -71,7 +71,7 @@
 
 \subsection{ENGINE START}
 \begin{checklistenumerate}
-    \blueitem[Engine Start]{\cbstart
+    \blueitem[Engine Start]\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/engine_start.pdf}
@@ -85,8 +85,8 @@
         \item \textbf{ENGINE Warning Light} \dotfill \textbf{OFF} \\
         \hfill (once 60\% RPM reached)
         \item \textbf{JFS Switch} \dotfill \textbf{Confirm OFF}
-    \end{enumerate}\cbend}
-    \blueitem[ENG Instruments]{
+    \end{enumerate}\cbend
+    \blueitem[ENG Instruments]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/engine_instruments.pdf}
@@ -99,7 +99,7 @@
         \item \textbf{RPM} --- 62-80\% 
         \item \textbf{FTIT} --- 650C or less
         \item \textbf{HYD PRES A \& B} --- 2850-3250 PSI
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \notebox{
@@ -110,7 +110,7 @@
 
 \subsection{POST-START}
 \begin{checklistenumerate}
-    \blueitem[TEST Panel]{
+    \blueitem[TEST Panel]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/test_panel.pdf}
@@ -125,8 +125,8 @@
         \item \textbf{FIRE \& OHEAT DETECT} \dotfill \textbf{TEST}
         \item \textbf{OXY QTY Test Switch} \dotfill \textbf{TEST}
         \item \textbf{MAL \& IND LTS Button} \dotfill \textbf{TEST}
-    \end{enumerate}}
-    \blueitem[AVIONICS Panel]{\cbstart
+    \end{enumerate}
+    \blueitem[AVIONICS Panel]\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/avionics_ins.pdf}
@@ -140,16 +140,16 @@
         \item \textbf{GPS Switch} \dotfill \textbf{GPS}
         \item \textbf{DL Switch} \dotfill \textbf{DL}
         \item \textbf{MIDS LVT Knob} \dotfill \textbf{ON}
-    \end{enumerate}}
-    \blueitem[INS Alignment]{
+    \end{enumerate}
+    \blueitem[INS Alignment]
     \begin{enumerate}
         \item \textbf{EGI/INS} \dotfill \textbf{Desired ALIGN Mode} \\
         \begin{itemize}
             \item \textbf{NORM} --- full align, approx. 8 min
             \item \textbf{STOR HDG} --- quick align, approx. 90 sec
         \end{itemize}
-    \end{enumerate}}
-    \blueitem[SNSR PWR Panel]{
+    \end{enumerate}
+    \blueitem[SNSR PWR Panel]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/snsr_pwr.pdf}
@@ -162,13 +162,13 @@
         \hfill (if targeting pod installed)
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{RDR ALT Switch} \dotfill \textbf{RDR ALT}
-    \end{enumerate}\cbend}
+    \end{enumerate}\cbend
 \end{checklistenumerate}
 
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem[HUD Setup]{\cbstart
+    \blueitem[HUD Setup]\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/hud_sai.pdf}
@@ -177,27 +177,27 @@
     \begin{enumerate}
         \item \textbf{HUD Control Panel} \dotfill \textbf{As Desired}
         \item \textbf{HUD Brightness} \dotfill \textbf{As Desired} 
-    \end{enumerate}\cbend}
-    \blueitem[C\&I Knob]{\dotfill\textbf{UFC}}
-    \blueitem[ECM Panel]{\cbstart\dotfill\textbf{As Desired}\cbend}
-    \blueitem[SPD BRK Check]{\dotfill\textbf{Cycle} (back to closed)}
-    \blueitem[WHEELS Down Lights]{\dotfill Verify \textbf{Three Green}}
-    \blueitem[\cbstart  Standby Attitude Indicator\cbend]{\dotfill\textbf{Set}}
-    \blueitem[Tests \& Checks]{\dotfill\hyperref[subsec:testschecks]{\textbf{See \Cref{subsec:testschecks}}}}
-    \blueitem[Avionics Setup]{%
+    \end{enumerate}\cbend
+    \blueitem[C\&I Knob]\dotfill\textbf{UFC}
+    \blueitem[ECM Panel]\cbstart\dotfill\textbf{As Desired}\cbend
+    \blueitem[SPD BRK Check]\dotfill\textbf{Cycle} (back to closed)
+    \blueitem[WHEELS Down Lights]\dotfill Verify \textbf{Three Green}
+    \blueitem[\cbstart  Standby Attitude Indicator\cbend]\dotfill\textbf{Set}
+    \blueitem[Tests \& Checks]\dotfill\hyperref[subsec:testschecks]{\textbf{See \Cref{subsec:testschecks}}}
+    \blueitem[Avionics Setup]
     \marginpar{%
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/final_setup.pdf}
         \caption{Final Setup}
     }
-    \cbstart\dotfill\textbf{Program As Required}}
-    \blueitem[Canopy]{\dotfill\textbf{Close and Lock}}
-    \blueitem[Altimeter]{\dotfill\textbf{Set and Check}}
-    \blueitem[Exterior Lights]{\dotfill\textbf{As Desired}}
-    \blueitem[INS Knob]{\dotfill\textbf{NAV}\cbend}
-    \blueitem[NWS]{\dotfill\textbf{Engage}}
-    \blueitem[Throttle]{\dotfill\textbf{Advance} (Check brakes \& NWS)}
-    \blueitem[Flight Instruments]{\dotfill\textbf{Check}}
+    \cbstart\dotfill\textbf{Program As Required}
+    \blueitem[Canopy]\dotfill\textbf{Close and Lock}
+    \blueitem[Altimeter]\dotfill\textbf{Set and Check}
+    \blueitem[Exterior Lights]\dotfill\textbf{As Desired}
+    \blueitem[INS Knob]\dotfill\textbf{NAV}\cbend
+    \blueitem[NWS]\dotfill\textbf{Engage}
+    \blueitem[Throttle]\dotfill\textbf{Advance} (Check brakes \& NWS)
+    \blueitem[Flight Instruments]\dotfill\textbf{Check}
 \end{checklistenumerate}
 
 % \clearpage
@@ -215,7 +215,7 @@
 \subsection{TESTS \& CHECKS}
 \label{subsec:testschecks}
 \begin{checklistenumerate}
-    \blueitem[ENG SEC Mode]{
+    \blueitem[ENG SEC Mode]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_eng_sec.pdf}
@@ -234,8 +234,8 @@
             \item \textbf{SEC Caution Light} --- \textbf{OFF}
             \item \textbf{NOZ POS} --- > 94\% 
         \end{itemize}
-    \end{enumerate}}
-    \blueitem[FLCS BIT]{
+    \end{enumerate}
+    \blueitem[FLCS BIT]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_flcs_bit.pdf}
@@ -254,13 +254,13 @@
             \item \textbf{FAIL Light} --- Verify \textbf{OFF}
             \item \textbf{FLCS Warning Light} --- Verify \textbf{OFF}
         \end{itemize}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem[FUEL QTY Check]{
+    \blueitem[FUEL QTY Check]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_fuel_qty.pdf}
@@ -291,8 +291,8 @@
             \hfill 2300/2420 lbs  (if loaded)
         \end{itemize}
         \item \textbf{FUEL QTY SEL Knob} \dotfill \textbf{As Desired}
-    \end{enumerate}}
-    \blueitem[DBU Check]{
+    \end{enumerate}
+    \blueitem[DBU Check]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_dbu.pdf}
@@ -305,8 +305,8 @@
         \end{itemize}
         \item Operate Controls --- check for normal control surface response
         \item \textbf{DIGITAL BACKUP Switch} \dotfill \textbf{OFF}
-    \end{enumerate}}
-    \blueitem[Trim Check]{
+    \end{enumerate}
+    \blueitem[Trim Check]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_trim.pdf}
@@ -326,13 +326,13 @@
             \item TRIM wheel motion
         \end{itemize} 
         \item \textbf{Yaw Trim Knob} \dotfill \textbf{Center}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem[MPO Check]{
+    \blueitem[MPO Check]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_mpo.pdf}
@@ -345,8 +345,8 @@
             \item Horizontal Tail trailing edges move farther down
         \end{itemize} 
         \item \textbf{Stick \& MPO} \dotfill Release
-    \end{enumerate}}
-    \blueitem[EPU Check]{
+    \end{enumerate}
+    \blueitem[EPU Check]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_epu.pdf}
@@ -366,7 +366,7 @@
         \item \textbf{EPU/GEN TEST Switch} \dotfill \textbf{OFF}
         \item \textbf{Throttle} \dotfill \textbf{IDLE}
         \item \textbf{OXYGEN} \dotfill \textbf{NORMAL}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/proc_basic/startup.tex
+++ b/src/chapters/proc_basic/startup.tex
@@ -4,7 +4,7 @@
 
 \subsection{PRE-START}
 \begin{checklistenumerate}
-    \blueitem{Verify Check}{\cbstart
+    \blueitem[Verify Check]\cbstart
     \marwarningbox{
         \small\textbf{If switches not positioned correctly, could lead to malfunction or hazard during startup}
     }
@@ -19,8 +19,8 @@
         \item \textbf{MASTER ARM Switch} \dotfill \textbf{OFF}
         \item \textbf{AIR SOURCE Knob} \dotfill \textbf{NORM}
     \end{enumerate}
-    \cbend}
-    \blueitem{\hyperref[fig:proc_basic:prestart:flcscheck]{FLCS Check}}{
+    \cbend
+    \blueitem[{\hyperref[fig:proc_basic:prestart:flcscheck]{FLCS Check}}]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/flcs_check.pdf}
@@ -41,8 +41,8 @@
             \item \textbf{FLCS RLY} --- \textbf{OFF}
         \end{itemize}
         \item \textbf{FLCS PWR TEST} \dotfill \textbf{Release}
-    \end{enumerate}}
-    \blueitem{\hyperref[fig:proc_basic:prestart:mainpower]{Main Power}}{
+    \end{enumerate}
+    \blueitem[{\hyperref[fig:proc_basic:prestart:mainpower]{Main Power}}]
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/main_power.pdf}
@@ -64,14 +64,14 @@
             \item \textbf{EPU GEN Light} --- \textbf{OFF}
             \item \textbf{EPU PMG Light} --- \textbf{OFF}
         \end{itemize}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
 
 \subsection{ENGINE START}
 \begin{checklistenumerate}
-    \blueitem{Engine Start}{\cbstart
+    \blueitem[Engine Start]{\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/engine_start.pdf}
@@ -86,7 +86,7 @@
         \hfill (once 60\% RPM reached)
         \item \textbf{JFS Switch} \dotfill \textbf{Confirm OFF}
     \end{enumerate}\cbend}
-    \blueitem{ENG Instruments}{
+    \blueitem[ENG Instruments]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/engine_instruments.pdf}
@@ -110,7 +110,7 @@
 
 \subsection{POST-START}
 \begin{checklistenumerate}
-    \blueitem{TEST Panel}{
+    \blueitem[TEST Panel]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/test_panel.pdf}
@@ -126,7 +126,7 @@
         \item \textbf{OXY QTY Test Switch} \dotfill \textbf{TEST}
         \item \textbf{MAL \& IND LTS Button} \dotfill \textbf{TEST}
     \end{enumerate}}
-    \blueitem{AVIONICS Panel}{\cbstart
+    \blueitem[AVIONICS Panel]{\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/avionics_ins.pdf}
@@ -141,7 +141,7 @@
         \item \textbf{DL Switch} \dotfill \textbf{DL}
         \item \textbf{MIDS LVT Knob} \dotfill \textbf{ON}
     \end{enumerate}}
-    \blueitem{INS Alignment}{
+    \blueitem[INS Alignment]{
     \begin{enumerate}
         \item \textbf{EGI/INS} \dotfill \textbf{Desired ALIGN Mode} \\
         \begin{itemize}
@@ -149,7 +149,7 @@
             \item \textbf{STOR HDG} --- quick align, approx. 90 sec
         \end{itemize}
     \end{enumerate}}
-    \blueitem{SNSR PWR Panel}{
+    \blueitem[SNSR PWR Panel]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/snsr_pwr.pdf}
@@ -168,7 +168,7 @@
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem{HUD Setup}{\cbstart
+    \blueitem[HUD Setup]{\cbstart
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/hud_sai.pdf}
@@ -178,26 +178,26 @@
         \item \textbf{HUD Control Panel} \dotfill \textbf{As Desired}
         \item \textbf{HUD Brightness} \dotfill \textbf{As Desired} 
     \end{enumerate}\cbend}
-    \blueitem{C\&I Knob}{\dotfill\textbf{UFC}}
-    \blueitem{ECM Panel}{\cbstart\dotfill\textbf{As Desired}\cbend}
-    \blueitem{SPD BRK Check}{\dotfill\textbf{Cycle} (back to closed)}
-    \blueitem{WHEELS Down Lights}{\dotfill Verify \textbf{Three Green}}
-    \blueitem{\cbstart  Standby Attitude Indicator\cbend}{\dotfill\textbf{Set}}
-    \blueitem{Tests \& Checks}{\dotfill\hyperref[subsec:testschecks]{\textbf{See \Cref{subsec:testschecks}}}}
-    \blueitem{Avionics Setup}{%
+    \blueitem[C\&I Knob]{\dotfill\textbf{UFC}}
+    \blueitem[ECM Panel]{\cbstart\dotfill\textbf{As Desired}\cbend}
+    \blueitem[SPD BRK Check]{\dotfill\textbf{Cycle} (back to closed)}
+    \blueitem[WHEELS Down Lights]{\dotfill Verify \textbf{Three Green}}
+    \blueitem[\cbstart  Standby Attitude Indicator\cbend]{\dotfill\textbf{Set}}
+    \blueitem[Tests \& Checks]{\dotfill\hyperref[subsec:testschecks]{\textbf{See \Cref{subsec:testschecks}}}}
+    \blueitem[Avionics Setup]{%
     \marginpar{%
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/final_setup.pdf}
         \caption{Final Setup}
     }
     \cbstart\dotfill\textbf{Program As Required}}
-    \blueitem{Canopy}{\dotfill\textbf{Close and Lock}}
-    \blueitem{Altimeter}{\dotfill\textbf{Set and Check}}
-    \blueitem{Exterior Lights}{\dotfill\textbf{As Desired}}
-    \blueitem{INS Knob}{\dotfill\textbf{NAV}\cbend}
-    \blueitem{NWS}{\dotfill\textbf{Engage}}
-    \blueitem{Throttle}{\dotfill\textbf{Advance} (Check brakes \& NWS)}
-    \blueitem{Flight Instruments}{\dotfill\textbf{Check}}
+    \blueitem[Canopy]{\dotfill\textbf{Close and Lock}}
+    \blueitem[Altimeter]{\dotfill\textbf{Set and Check}}
+    \blueitem[Exterior Lights]{\dotfill\textbf{As Desired}}
+    \blueitem[INS Knob]{\dotfill\textbf{NAV}\cbend}
+    \blueitem[NWS]{\dotfill\textbf{Engage}}
+    \blueitem[Throttle]{\dotfill\textbf{Advance} (Check brakes \& NWS)}
+    \blueitem[Flight Instruments]{\dotfill\textbf{Check}}
 \end{checklistenumerate}
 
 % \clearpage
@@ -215,7 +215,7 @@
 \subsection{TESTS \& CHECKS}
 \label{subsec:testschecks}
 \begin{checklistenumerate}
-    \blueitem{ENG SEC Mode}{
+    \blueitem[ENG SEC Mode]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_eng_sec.pdf}
@@ -235,7 +235,7 @@
             \item \textbf{NOZ POS} --- > 94\% 
         \end{itemize}
     \end{enumerate}}
-    \blueitem{FLCS BIT}{
+    \blueitem[FLCS BIT]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_flcs_bit.pdf}
@@ -260,7 +260,7 @@
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem{FUEL QTY Check}{
+    \blueitem[FUEL QTY Check]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_fuel_qty.pdf}
@@ -292,7 +292,7 @@
         \end{itemize}
         \item \textbf{FUEL QTY SEL Knob} \dotfill \textbf{As Desired}
     \end{enumerate}}
-    \blueitem{DBU Check}{
+    \blueitem[DBU Check]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_dbu.pdf}
@@ -306,7 +306,7 @@
         \item Operate Controls --- check for normal control surface response
         \item \textbf{DIGITAL BACKUP Switch} \dotfill \textbf{OFF}
     \end{enumerate}}
-    \blueitem{Trim Check}{
+    \blueitem[Trim Check]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_trim.pdf}
@@ -332,7 +332,7 @@
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem{MPO Check}{
+    \blueitem[MPO Check]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_mpo.pdf}
@@ -346,7 +346,7 @@
         \end{itemize} 
         \item \textbf{Stick \& MPO} \dotfill Release
     \end{enumerate}}
-    \blueitem{EPU Check}{
+    \blueitem[EPU Check]{
     \marginpar{
         \captionsetup{type=figure}
         \includegraphics[width=\marginparwidth]{diagrams/cockpit/check_epu.pdf}

--- a/src/chapters/proc_basic/to_ldg.tex
+++ b/src/chapters/proc_basic/to_ldg.tex
@@ -327,7 +327,7 @@
         \item \textbf{Throttle} --- \textbf{Idle}
         \item \textbf{AoA} --- \textbf{< 13 deg}
     \end{itemize}
-    \blueitem[Touchdown]{}
+    \blueitem[Touchdown]
     \blueitem[Landing Roll] Maintain nose-high position for aerobraking until 100 kts
     \begin{itemize}
         \item \textbf{AoA} --- \textbf{< 13 deg}

--- a/src/chapters/proc_basic/to_ldg.tex
+++ b/src/chapters/proc_basic/to_ldg.tex
@@ -4,36 +4,36 @@
 
 \subsection{PRE-TAKEOFF}
 \begin{checklistenumerate}
-    \blueitem{ALT FLAPS Switch}{\dotfill\textbf{Verify Norm}}
-    \blueitem{Trim}{\dotfill\textbf{Check}}
-    \blueitem{ENG CONT Switch}{\dotfill\textbf{Verify PRI}}
-    \blueitem{Speedbrakes}{\dotfill\textbf{Closed}}
-    \blueitem{Canopy}{\dotfill\textbf{Verify Closed \& Locked}}
-    \blueitem{IFF}{\dotfill\textbf{Set \& Check}}
-    \blueitem{FUEL QTY Select Knob}{\dotfill\textbf{NORM}}
-    \blueitem{STORES CONFIG Switch}{\dotfill\textbf{As Required}
+    \blueitem[ALT FLAPS Switch]\dotfill\textbf{Verify Norm}
+    \blueitem[Trim]\dotfill\textbf{Check}
+    \blueitem[ENG CONT Switch]\dotfill\textbf{Verify PRI}
+    \blueitem[Speedbrakes]\dotfill\textbf{Closed}
+    \blueitem[Canopy]\dotfill\textbf{Verify Closed \& Locked}
+    \blueitem[IFF]\dotfill\textbf{Set \& Check}
+    \blueitem[FUEL QTY Select Knob]\dotfill\textbf{NORM}
+    \blueitem[STORES CONFIG Switch]\dotfill\textbf{As Required}
     
     \begin{itemize}
         \item \textbf{CAT I} --- \textbf{A-A Loadouts} 
         \item \textbf{CAT III} --- \textbf{A-G / Wing tank Loadouts}
-    \end{itemize}}
-    \blueitem{PROBE HEAT Switch}{\dotfill\textbf{PROBE HEAT}}
-    \blueitem{Ejection Safety Lever}{\cbstart\dotfill\textbf{Arm (down)}\cbend}
-    \blueitem{Flight Controls}{\dotfill\textbf{Cycle}}
-    \blueitem{Oil Pressure}{\dotfill\textbf{15-65 psi}}
-    \blueitem{TGP}{\dotfill\textbf{STOW} (if installed)}
-    \blueitem{Warning \& Caution Lights}{\dotfill\textbf{Verify Off}}
+    \end{itemize}
+    \blueitem[PROBE HEAT Switch]\dotfill\textbf{PROBE HEAT}
+    \blueitem[Ejection Safety Lever]\cbstart\dotfill\textbf{Arm (down)}\cbend
+    \blueitem[Flight Controls]\dotfill\textbf{Cycle}
+    \blueitem[Oil Pressure]\dotfill\textbf{15-65 psi}
+    \blueitem[TGP]\dotfill\textbf{STOW} (if installed)
+    \blueitem[Warning \& Caution Lights]\dotfill\textbf{Verify Off}
 \end{checklistenumerate}
 
 \subsection{TAKEOFF}
 
 \begin{checklistenumerate}
-    \blueitem{Runup}{\cbstart
+    \blueitem[Runup]\cbstart
     \begin{enumerate}
         \item \textbf{Brake} \dotfill \textbf{Hold}
         \item \textbf{Throttle} \dotfill \textbf{90\%}\cbend
-    \end{enumerate}}
-    \blueitem{Runup Check}{
+    \end{enumerate}
+    \blueitem[Runup Check]
     \begin{enumerate}
         \item \textbf{Parking Brake} \dotfill \textbf{Verify disengaged}
         \item \textbf{Engine Parameters} \dotfill \textbf{Nominal}
@@ -47,13 +47,13 @@
             \item \textbf{FTIT} --- \textbf{less than 935deg}
             \item \textbf{HYD PRESS A \& B} --- \textbf{2850-3250psi}
         \end{itemize}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem{Takeoff Roll}{\cbstart
+    \blueitem[Takeoff Roll]\cbstart
     \marginpar{
         \captionsetup{type=table}
         \centering
@@ -92,8 +92,8 @@
 
     \begin{enumerate}[start=3]
         \item \textbf{NWS} \dotfill \textbf{Disengaged}
-    \end{enumerate}}
-    \blueitem{Rotation}{\cbstart
+    \end{enumerate}
+    \blueitem[Rotation]\cbstart
     At 10-15kts below takeoff speed, reference \cref{tab:proc:takeoff:speed}
 
     \begin{enumerate}
@@ -107,7 +107,6 @@
     \end{enumerate}%
     \marwarningbox{%
         \small\textbf{Exceeding 13 deg AOA can result in a tail strike!}%
-    }%
     }%
 \end{checklistenumerate}
 
@@ -152,18 +151,18 @@
 \subsection{PRE-LANDING}
 
 \begin{checklistenumerate}
-    \blueitem{Fuel}{\dotfill\textbf{Check}}
-    \blueitem{Landing Light}{\dotfill\textbf{ON}}
-    \blueitem{Altimeter}{\dotfill\textbf{Set \& Check}}
-    \blueitem{Attitude References}{\dotfill\textbf{Check}}
-    \blueitem{Anti-Ice}{\dotfill\textbf{As Required}}
-    \blueitem{TGP}{\dotfill\textbf{STOW} (if installed)}
+    \blueitem[Fuel]\dotfill\textbf{Check}
+    \blueitem[Landing Light]\dotfill\textbf{ON}
+    \blueitem[Altimeter]\dotfill\textbf{Set \& Check}
+    \blueitem[Attitude References]\dotfill\textbf{Check}
+    \blueitem[Anti-Ice]\dotfill\textbf{As Required}
+    \blueitem[TGP]\dotfill\textbf{STOW} (if installed)
 \end{checklistenumerate}
 
 \subsection{LANDING}
 
 \begin{checklistenumerate}
-    \blueitem{Approach}{Align aircraft with runway
+    \blueitem[Approach] Align aircraft with runway
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -228,42 +227,42 @@
     \begin{itemize}
         \item \textbf{Altitude} --- \textbf{1500 ft AGL}
         \item \textbf{Airspeed} --- \textbf{300 kts CAS}
-    \end{itemize}}
-    \blueitem{Overhead Break}{Break left/right over desired touchdown point, \textbf{\underline{maintain level turn}}
+    \end{itemize}
+    \blueitem[Overhead Break] Break left/right over desired touchdown point, \textbf{\underline{maintain level turn}}
 
     \begin{itemize}
         \item \textbf{Speedbrakes} --- \textbf{As Required}
         \item \textbf{Throttle} --- \textbf{As Required}
         \item \textbf{Bank} --- \textbf{70 deg}
         \item \textbf{Break} --- \textbf{1\% of airspeed in G}
-    \end{itemize}}
-    \blueitem{Downwind Leg}{Roll out on opposite heading of runway, max 13 deg AoA
+    \end{itemize}
+    \blueitem[Downwind Leg] Roll out on opposite heading of runway, max 13 deg AoA
 
     \begin{itemize}
         \item \textbf{Altitude} --- \textbf{1500 ft AGL}
         \item \textbf{Airspeed} --- \textbf{200-220 kts CAS}
         \item \textbf{Gear} --- \textbf{Down}
-    \end{itemize}}
-    \blueitem{Base Turn}{Initiate abeam of desired touchdown point (wingtip at end of runway)
+    \end{itemize}
+    \blueitem[Base Turn] Initiate abeam of desired touchdown point (wingtip at end of runway)
 
     \begin{itemize}
         \item \textbf{Attitude} --- \textbf{8-10 deg nose low}
         \item \textbf{AoA} --- \textbf{< 13 deg}
-    \end{itemize}}
-    \blueitem{Final Turn}{Use throttle to maintain AoA, stick to maintain attitude, goal is to roll wings-level at
+    \end{itemize}
+    \blueitem[Final Turn] Use throttle to maintain AoA, stick to maintain attitude, goal is to roll wings-level at
 
     \begin{itemize}
         \item \textbf{1 mile} from desired touchdown point
         \item \textbf{Altitude} --- \textbf{300 ft AGL}
         % \item \textbf{AoA} --- \textbf{max 13 deg}
         \item \textbf{Flightpath} --- align  with \textbf{2.5 deg HUD marker} and runway threshold
-    \end{itemize}}
+    \end{itemize}
 \end{checklistenumerate}
 
 \clearpage
 
 \begin{checklistenumerate}[resume]
-    \blueitem{Short Final}{Once over runway
+    \blueitem[Short Final] Once over runway
     
     \marginpar{
         \captionsetup{type=figure}
@@ -327,38 +326,38 @@
         \item \textbf{Flare} --- gently pull back on stick
         \item \textbf{Throttle} --- \textbf{Idle}
         \item \textbf{AoA} --- \textbf{< 13 deg}
-    \end{itemize}}
-    \blueitem{Touchdown}{}
-    \blueitem{Landing Roll}{Maintain nose-high position for aerobraking until 100 kts
+    \end{itemize}
+    \blueitem[Touchdown]{}
+    \blueitem[Landing Roll] Maintain nose-high position for aerobraking until 100 kts
     \begin{itemize}
         \item \textbf{AoA} --- \textbf{< 13 deg}
         \item \textbf{Speedbrakes} --- \textbf{Open}
         \item \textbf{Brakes} --- \textbf{As Required}
-    \end{itemize}}
-    \blueitem{Taxi}{
+    \end{itemize}
+    \blueitem[Taxi]
     \begin{itemize}
         \item \textbf{NWS} --- \textbf{Engaged}
-    \end{itemize}}
+    \end{itemize}
 \end{checklistenumerate}
 
 \clearpage
 
 \subsection{POST-LANDING}
 \begin{checklistenumerate}
-    \blueitem{PROBE HEAT Switch}{\dotfill\textbf{OFF}}
-    \blueitem{ECM Power}{\dotfill\textbf{OFF}}
-    \blueitem{Speedbrakes}{\dotfill\textbf{Close}}
-    \blueitem{Ejection Safety Lever}{\dotfill\textbf{Safe (up)}}
-    \blueitem{IFF Master Knob}{\dotfill\textbf{STBY}}
-    \blueitem{Landing/Taxi Light}{\dotfill\textbf{As Desired}}
-    \blueitem{Armament Switches}{\dotfill\textbf{Safe}}
-    \blueitem{Avionics}{\dotfill\textbf{Off}
+    \blueitem[PROBE HEAT Switch]\dotfill\textbf{OFF}
+    \blueitem[ECM Power]\dotfill\textbf{OFF}
+    \blueitem[Speedbrakes]\dotfill\textbf{Close}
+    \blueitem[Ejection Safety Lever]\dotfill\textbf{Safe (up)}
+    \blueitem[IFF Master Knob]\dotfill\textbf{STBY}
+    \blueitem[Landing/Taxi Light]\dotfill\textbf{As Desired}
+    \blueitem[Armament Switches]\dotfill\textbf{Safe}
+    \blueitem[Avionics]\dotfill\textbf{Off}
     \begin{itemize}
         \item \textbf{HUD Thumbwheels} --- \textbf{Off}
         \item \textbf{SNSR PWR Switches} --- \textbf{Off}
         \item \textbf{AVIONICS PWR Switches} --- \textbf{Off}
-    \end{itemize}}
-    \blueitem{Engine Shutdown}{
+    \end{itemize}
+    \blueitem[Engine Shutdown]
     \begin{enumerate}
         \item \textbf{Throttle} \dotfill \textbf{Off}
         \item \textbf{Lights} \dotfill \textbf{Check}
@@ -368,9 +367,9 @@
             \item \textbf{EPU PMG Light} --- \textbf{Off}
         \end{itemize}
         \item \textbf{Main PWR Switch} \dotfill \textbf{OFF}
-    \end{enumerate}}
-    \blueitem{Oxygen Regulator}{\dotfill\textbf{Off}}
-    \blueitem{Canopy}{\dotfill\textbf{Open}}
+    \end{enumerate}
+    \blueitem[Oxygen Regulator]\dotfill\textbf{Off}
+    \blueitem[Canopy]\dotfill\textbf{Open}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/sensors_aa/apg68_fcr.tex
+++ b/src/chapters/sensors_aa/apg68_fcr.tex
@@ -2,7 +2,7 @@
 
 \subsection{OVERVIEW}
 \begin{tcoloritemize}
-    \blueitem{A-A Modes}{
+    \blueitem[A-A Modes]
     \begin{itemize}
         \item \textbf{CRM} --- \textbf{C}ombined \textbf{R}adar \textbf{M}ode, \break see \Cref{subsec:crm}
         \begin{itemize}
@@ -11,12 +11,13 @@
         \end{itemize}
         \item \textbf{ACM} --- \textbf{A}ir \textbf{C}ombat \textbf{M}ode, see \Cref{subsec:acm}
         \item \textbf{STT} --- \textbf{S}ingle \textbf{T}arget \textbf{T}rack, see \Cref{subsec:stt}
-    \end{itemize}}
-    \blueitem{A-G Modes}{\textbf{Work In Progress}
+    \end{itemize}
+    \blueitem[A-G Modes]
+    \textbf{Work In Progress}
     \begin{itemize}
         \item \textbf{GM} --- \textbf{G}round \textbf{M}ap
         \item \textbf{GMT} --- \textbf{G}round \textbf{M}oving \textbf{T}arget
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]

--- a/src/chapters/sensors_aa/apg68_fcr/acm.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/acm.tex
@@ -1,7 +1,7 @@
 \subsection{ACM}
 \label{subsec:acm}
 \begin{tcoloritemize}
-    \blueitem{ACM}{
+    \blueitem[ACM]
     \textbf{A}ir \textbf{C}ombat \textbf{M}ode
 
     \begin{itemize}
@@ -13,7 +13,7 @@
             \item \textbf{Vertical Scan} --- 10x60 deg
             \item \textbf{Slewable} --- WIP
         \end{itemize}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -296,7 +296,7 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{HUD Submode}{
+    \blueitem[HUD Submode]
     \begin{itemize}
         \item \textbf{30x20 deg scan} --- slightly larger than HUD
         \item \textbf{Lock Range} --- 10 nm
@@ -307,8 +307,8 @@
             \item \textbf{FCR Format} --- displays \textbf{ACM 20}
             \item \textbf{HUD} --- no special symbology
         \end{itemize}
-    \end{itemize}}
-    \blueitem{BORE Submode}{
+    \end{itemize}
+    \blueitem[BORE Submode]
     \begin{itemize}
         \item \textbf{Small, 1-beamwidth scan}
         \begin{itemize}
@@ -324,8 +324,8 @@
             \item \textbf{HUD} --- Boresight Cross at center of radar scan zone
             \item \textbf{HMD} --- Oval centered on HMD aiming cross
         \end{itemize}
-    \end{itemize}}
-    \blueitem{Vertical \break Submode}{
+    \end{itemize}
+    \blueitem[Vertical \break Submode]
     \begin{itemize}
         \item \textbf{10x60 deg scan}
         \begin{itemize}
@@ -339,8 +339,8 @@
             \item \textbf{FCR Format} --- displays \textbf{ACM 60}
             \item \textbf{HUD} --- Vertical line
         \end{itemize}
-    \end{itemize}}
-    \blueitem{Slewable \break Submode --- WIP}{
+    \end{itemize}
+    \blueitem[Slewable \break Submode --- WIP]
     \begin{itemize}
         \item \textbf{Scan} --- WIP
         \item \textbf{Lock Range} --- WIP
@@ -350,15 +350,15 @@
             \item \textbf{FCR Format} --- displays \textbf{ACM SLEW}
             \item \textbf{HUD} --- WIP
         \end{itemize}
-    \end{itemize}}
-    \blueitem{NO RAD}{Upon selection of \textbf{ACM} or dropping target lock the radar is placed in non-radiating state}
+    \end{itemize}
+    \blueitem[NO RAD]{Upon selection of \textbf{ACM} or dropping target lock the radar is placed in non-radiating state}
 \end{tcoloritemize}
 
 \marginfigeometry
 
 \subsubsection{HUD / BORE / VERTICAL ACQUISITION}
 \begin{checklistenumerate}
-    \blueitem{FCR Setup}{
+    \blueitem[FCR Setup]
     \marginpar{
         \captionsetup{type=figure}
         \begin{subfigure}[t]{\linewidth}
@@ -420,35 +420,35 @@
     \begin{enumerate}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{Desired MFD} \dotfill \textbf{FCR Page}
-    \end{enumerate}}
-    \blueitem{Enter ACM}{
+    \end{enumerate}
+    \blueitem[Enter ACM]
     \begin{enumerate}
         \item \textbf{Dogfight/Missile Override} \dotfill \textbf{DGFT}
         \item \textbf{Radar Mode (OSB 2)} \dotfill verify \textbf{ACM}
-    \end{enumerate}}
-    \blueitem{Select ACM Submode}{
+    \end{enumerate}
+    \blueitem[Select ACM Submode]
     \begin{itemize}
         \item \textbf{HUD} (default ACM mode) \dotfill \textbf{TMS Right}
         \item \textbf{Bore} \dotfill \textbf{TMS Forward}
         \item \textbf{Vertical} \dotfill \textbf{TMS Aft}
-    \end{itemize}}
-    \blueitem{Target Acquisition}{
+    \end{itemize}
+    \blueitem[Target Acquisition]
     \begin{enumerate}
         \item Maneuver aircraft to place target within selected ACM scan volume 
         \item Wait for automatic transition to STT 
-    \end{enumerate}}
-    \blueitem{Target Rejection}{%
+    \end{enumerate}
+    \blueitem[Target Rejection]
     To unlock target
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Aft}
     \end{enumerate}
     Radar returns to \textbf{HUD} submode in \textbf{NO RAD} 
-    }
+    
 \end{checklistenumerate}
 
 \subsubsection{HMD ACQUISITION}
 \begin{checklistenumerate}
-    \blueitem{FCR/MFD Setup}{
+    \blueitem[FCR/MFD Setup]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -461,29 +461,28 @@
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{Desired MFD} \dotfill \textbf{FCR Page}
         \item \textbf{HMD Brightness} \dotfill \textbf{On}
-    \end{enumerate}}
-    \blueitem{Enter ACM}{
+    \end{enumerate}
+    \blueitem[Enter ACM]
     \begin{enumerate}
         \item \textbf{Dogfight/Missile Override} \dotfill \textbf{DGFT}
         \item \textbf{Radar Mode (OSB 2)} \dotfill verify \textbf{ACM}
-    \end{enumerate}}
-    \blueitem{Select ACM Bore Submode}{
+    \end{enumerate}
+    \blueitem[Select ACM Bore Submode]
     \begin{itemize}
         \item \textbf{Bore} \dotfill \textbf{TMS Forward}
-    \end{itemize}}
-    \blueitem{Target Acquisition}{
+    \end{itemize}
+    \blueitem[Target Acquisition]
     \begin{enumerate}
         \item Maneuver aircraft to place target within 60 deg of nose 
         \item Place target within HMD acquisition circle
         \item Wait for automatic transition to STT 
-    \end{enumerate}}
-    \blueitem{Target Rejection}{%
+    \end{enumerate}
+    \blueitem[Target Rejection]
     To unlock target
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Aft}
     \end{enumerate}
-    Radar returns to \textbf{HUD} submode in \textbf{NO RAD} 
-    }
+    Radar returns to \textbf{HUD} submode in \textbf{NO RAD}
 \end{checklistenumerate}
 
 \subsubsection{SLEWABLE ACQUISITION --- WIP}

--- a/src/chapters/sensors_aa/apg68_fcr/acm.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/acm.tex
@@ -351,7 +351,8 @@
             \item \textbf{HUD} --- WIP
         \end{itemize}
     \end{itemize}
-    \blueitem[NO RAD]{Upon selection of \textbf{ACM} or dropping target lock the radar is placed in non-radiating state}
+    \blueitem[NO RAD]
+    Upon selection of \textbf{ACM} or dropping target lock the radar is placed in non-radiating state
 \end{tcoloritemize}
 
 \marginfigeometry

--- a/src/chapters/sensors_aa/apg68_fcr/crm.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/crm.tex
@@ -2,7 +2,7 @@
 \label{subsec:crm}
 
 \begin{tcoloritemize}
-    \blueitem{CRM}{
+    \blueitem[CRM]
         \textbf{C}ombined \textbf{R}adar \textbf{M}ode --- Combines A-A search submodes:
 
         \begin{itemize}
@@ -15,12 +15,11 @@
         Selected by default on FCR start-up. 
         
         Reference \cref{fig:crmoverview}
-    }
-    \blueitem{Change CRM \break Submode}{
+    \blueitem[Change CRM \break Submode]
     \begin{itemize}
         \item \textbf{OSB 2} \dotfill \textbf{Press}
         \item Or \textbf{TMS} \dotfill \textbf{Right Long}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -151,14 +150,14 @@
 \subsubsection{A-A SEARCH SCAN PATTERN}
 
 \begin{tcoloritemize}
-    \blueitem{Radar Gimbal Limits}{
+    \blueitem[Radar Gimbal Limits]
     APG-68 is mechanically scanned on 2 axis gimbal
 
     \begin{itemize}
         \item \textbf{Azimuth} --- \pm60 deg (120 deg coverage)
         \item \textbf{Vertical} --- \pm60 deg (120 deg coverage)
-    \end{itemize}}
-    \blueitem{Azimuth Scan Pattern}{
+    \end{itemize}
+    \blueitem[Azimuth Scan Pattern]
     Horizontal scan volume controlled by selecting limits of gimbal azimuth
     \begin{itemize}
         \item \textbf{Azimuth search patterns}
@@ -179,15 +178,13 @@
         \end{itemize}
     \end{itemize}
     Reference \cref{fig:sensors_aa:apg68:crm:azscan} for graphical representation
-    }
-    \blueitem{Bar Scan Pattern}{
+    \blueitem[Bar Scan Pattern]
     Elevation scan volume controlled by selecting number of ``bars'' (horizontal sweeps)
     \begin{itemize}
         \item \textbf{B4} / \textbf{B2} / \textbf{B1} --- cycled via \textbf{OSB 17}
         \item \textbf{B3} --- selected by TWS \& DTT modes
     \end{itemize}
     Reference \cref{fig:sensors_aa:apg68:crm:barscan} for graphical representation
-    }
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -360,7 +357,7 @@
 \subsubsection{MFD CONTROLS}
 
 \begin{tcoloritemize}
-    \blueitem{Radar Mode}{
+    \blueitem[Radar Mode]
     \textbf{OSB 1} opens page allowing selection of radar mode
 
     \begin{itemize}
@@ -374,8 +371,8 @@
             \item see \cref{sec:fcr-ag}
         \end{itemize}
         \item \textbf{STBY (OSB 10)} --- places FCR in standby
-    \end{itemize}}
-    \blueitem{Field of View}{
+    \end{itemize}
+    \blueitem[Field of View]
     \textbf{OSB 3} cycles field of view
 
     \begin{itemize}
@@ -383,21 +380,20 @@
         \item \textbf{NORM} --- normal field of view
     \end{itemize}
 
-    HOTAS \textbf{EXPAND/FOV} switch also cycles FOV}
-    \blueitem{Override}{Pressing \textbf{OVRD (OSB 4)}  places FCR in standby}
-    \blueitem{FCR Control}{\textbf{CNTL (OSB 5)} opens FCR control page}
-    \blueitem{Datalink Mode}{\textbf{OSB 6} cycles datalink operating mode (WIP)}
-    \blueitem{Declutter}{\textbf{DCLT (OSB 11)} opens FCR declutter page, allowing pilot to deselect symbology elements}
-    \blueitem{Elevation Bar \break Select}{\textbf{OSB 17} cycles elevation bar search pattern}
-    \blueitem{Azimuth Select}{
-    \textbf{OSB 18} cycles azimuth search pattern}
-    \blueitem{Range Select}{
+    HOTAS \textbf{EXPAND/FOV} switch also cycles FOV
+    \blueitem[Override] Pressing \textbf{OVRD (OSB 4)}  places FCR in standby
+    \blueitem[FCR Control] \textbf{CNTL (OSB 5)} opens FCR control page
+    \blueitem[Datalink Mode] \textbf{OSB 6} cycles datalink operating mode (WIP)
+    \blueitem[Declutter] \textbf{DCLT (OSB 11)} opens FCR declutter page, allowing pilot to deselect symbology elements
+    \blueitem[Elevation Bar \break Select] \textbf{OSB 17} cycles elevation bar search pattern
+    \blueitem[Azimuth Select]
+    \textbf{OSB 18} cycles azimuth search pattern
+    \blueitem[Range Select]
     \textbf{OSB 19-20} adjusts FCR display range scale
     
     \begin{itemize}
         \item \textbf{Can be cycled by ``walking'' cursor off top/bottom of display}
     \end{itemize}
-    }
 \end{tcoloritemize}
 
 \notebox{

--- a/src/chapters/sensors_aa/apg68_fcr/rws.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/rws.tex
@@ -1,7 +1,7 @@
 \subsection{RWS}
 \label{subsec:rws}
 \begin{tcoloritemize}
-    \blueitem{RWS}{
+    \blueitem[RWS]
     \textbf{R}ange \textbf{W}hile \textbf{S}earch
 
     \begin{itemize}
@@ -17,7 +17,7 @@
         \end{itemize}
         % (exact target range, velocity, angle, etc.)
         % --- but can transition to advanced modes
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -56,7 +56,7 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{SAM \break Submode}{
+    \blueitem[SAM \break Submode]
     \textbf{S}ituational \textbf{A}warness \textbf{M}ode
 
     \begin{itemize}
@@ -70,8 +70,8 @@
             \item scan pauses on SAM target
             \item FCR manages scan volume
         \end{itemize}
-    \end{itemize}}
-    \blueitem{DTT \break Submode}{
+    \end{itemize}
+    \blueitem[DTT \break Submode]
     \textbf{D}ual \textbf{T}arget \textbf{T}rack
 
     \begin{itemize}
@@ -88,8 +88,8 @@
         \end{itemize}
         \item \textbf{Within 10nm search pattern inhibited} --- radar only scans primary/secondary targets
         \item \textbf{Once \underline{either} target within 3nm automatically transitions to STT}
-    \end{itemize}}
-    \blueitem{Spotlight}{
+    \end{itemize}
+    \blueitem[Spotlight]{
         
     \textbf{Narrow scan centered on acquisition cursor}
     \begin{itemize}
@@ -154,29 +154,27 @@
 
 \subsubsection{SELECT RWS MODE}
 \begin{checklistenumerate}
-    \blueitem{FCR Switch}{\textbf{FCR}}
-    \blueitem{Desired MFD}{\textbf{FCR Page}, verify \textbf{SOI}}
-    \blueitem{Radar Mode}{
+    \blueitem[FCR Switch] \textbf{FCR}
+    \blueitem[Desired MFD] \textbf{FCR Page}, verify \textbf{SOI}
+    \blueitem[Radar Mode]
         \textbf{CRM} (default), verify
 
         \begin{itemize}
             \item \textbf{Dogfight/Missile Override} --- \textbf{NORM}
             \item \textbf{Radar Mode (OSB 1)} --- shows \textbf{CRM}
         \end{itemize}
-    }
-    \blueitem{CRM Submode}{
+    \blueitem[CRM Submode]
         \textbf{RWS} (default), cycle via 
 
         \begin{itemize}
             \item \textbf{TMS Right (long)} / \textbf{OSB 2} 
         \end{itemize}
-    }
 \end{checklistenumerate}
 
 \subsubsection{SAM / DTT ACQUISITION}
 \label{subsec:rws:samdttacq}
 \begin{checklistenumerate}
-    \blueitem{Locate Targets}{
+    \blueitem[Locate Targets]
     \begin{enumerate}
         \item Correlate onboard/offboard sensors
         \begin{itemize}
@@ -184,8 +182,8 @@
             \item AWACS calls, datalink targets
         \end{itemize}
         \item Place targets within radar scan volume
-    \end{enumerate}}
-    \blueitem{SAM Acquisition}{
+    \end{enumerate}
+    \blueitem[SAM Acquisition]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -216,8 +214,8 @@
         \item Can guide AIM-120C on Bugged target
         \item DLZ displayed if missile selected
         \item RWS search continues
-    \end{itemize}}
-    \blueitem{DTT Acquisition}{(if desired)
+    \end{itemize}
+    \blueitem[DTT Acquisition] (if desired)
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -249,17 +247,16 @@
     \begin{enumerate}[start=3]
         \item \textbf{TMS} \dotfill \textbf{Left}
     \end{enumerate}
-    }
-    \blueitem{STT Lock}{(if desired)
+    \blueitem[STT Lock] (if desired)
     \begin{enumerate}
         \item \textbf{Target} \dotfill under Acquisition Cursor
         \item \textbf{TMS} \dotfill \textbf{Forward}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \subsubsection{SPOTLIGHT ACQUISITION}
 \begin{checklistenumerate}
-    \blueitem{Locate Targets}{
+    \blueitem[Locate Targets]
     \begin{enumerate}
         \item Correlate onboard/offboard sensors
         \begin{itemize}
@@ -267,8 +264,8 @@
             \item AWACS calls, datalink targets
         \end{itemize}
         \item Place target within radar scan limits
-    \end{enumerate}}
-    \blueitem{Spotlight Search}{
+    \end{enumerate}
+    \blueitem[Spotlight Search]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -321,8 +318,8 @@
         \begin{itemize}
             \item FCR enters \pm10deg scan around acquisition cursor
         \end{itemize}
-    \end{enumerate}}
-    \blueitem{SAM Acquisition}{
+    \end{enumerate}
+    \blueitem[SAM Acquisition]
     \begin{enumerate}
         \item \textbf{Target} \dotfill under Acquisition Cursor
         \item \textbf{TMS} \dotfill \textbf{Forward (release)}
@@ -332,12 +329,12 @@
         \item Can guide AIM-120C on Bugged target
         \item DLZ displayed if missile selected
         \item RWS search continues
-    \end{itemize}}
-    \blueitem{STT Lock}{(if desired)
+    \end{itemize}
+    \blueitem[STT Lock] (if desired)
     \begin{enumerate}
         \item \textbf{Target} \dotfill under Acquisition Cursor
         \item \textbf{TMS} \dotfill \textbf{Forward}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/sensors_aa/apg68_fcr/rws.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/rws.tex
@@ -89,7 +89,7 @@
         \item \textbf{Within 10nm search pattern inhibited} --- radar only scans primary/secondary targets
         \item \textbf{Once \underline{either} target within 3nm automatically transitions to STT}
     \end{itemize}
-    \blueitem[Spotlight]{
+    \blueitem[Spotlight]
         
     \textbf{Narrow scan centered on acquisition cursor}
     \begin{itemize}
@@ -104,7 +104,7 @@
             \item enters SAM submode if target detected under Acquisition Cursor
             \item returns to previous search pattern if no target under Acquisition Cursor when released
         \end{itemize}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]

--- a/src/chapters/sensors_aa/apg68_fcr/stt.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/stt.tex
@@ -1,7 +1,7 @@
 \subsection{STT}
 \label{subsec:stt}
 \begin{tcoloritemize}
-    \blueitem{STT}{
+    \blueitem[STT]
     \textbf{S}ingle \textbf{T}arget \textbf{T}rack
     \begin{itemize}
         \item \textbf{FCR continually scans one target}
@@ -16,8 +16,8 @@
             \item placing target in search volume of \textbf{ACM} (lock occurs automatically)
         \end{itemize}
         \item \textbf{Exited with TMS Aft} --- returns to search mode
-    \end{itemize}}
-    \blueitem{Display}{
+    \end{itemize}
+    \blueitem[Display]
     \begin{itemize}
         \item \textbf{Target state} shown at top of FCR page
         \begin{itemize}
@@ -26,8 +26,8 @@
             \item airspeed 
             \item closure rate
         \end{itemize}
-    \end{itemize}}
-    \blueitem{NCTR}{
+    \end{itemize}
+    \blueitem[NCTR]
     \textbf{N}on-\textbf{C}ooperative \textbf{T}arget \textbf{R}ecognition
     \begin{itemize}
         \item \textbf{FCR attempts to identify locked target}
@@ -42,7 +42,7 @@
         \end{itemize}
         \item \textbf{Activated with IFF interrogation (TMS Left long)}
         \item \textbf{Hostile NCTR identification counts towards ROE matrix} (combined with IFF return)
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]

--- a/src/chapters/sensors_aa/apg68_fcr/tws.tex
+++ b/src/chapters/sensors_aa/apg68_fcr/tws.tex
@@ -1,7 +1,7 @@
 \subsection{TWS}
 \label{subsec:tws}
 \begin{tcoloritemize}
-    \blueitem{TWS}{
+    \blueitem[TWS]
     \textbf{T}rack \textbf{W}hile \textbf{S}can --- reference \cref{fig:sensors_aa:apg68:tws:search} for symbology
 
     \begin{itemize}
@@ -22,7 +22,6 @@
     \end{itemize}
     
     Reference \cref{subsec:sensorsaa:apg68:tws:trackfile} for trackfile explanation \& \cref{fig:sensorsaa:apg68:tws:trackfile} for trackfile symbology
-    }
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -112,7 +111,7 @@
 \subsubsection{TRACKFILE STATES}
 \label{subsec:sensorsaa:apg68:tws:trackfile}
 \begin{tcoloritemize}
-    \blueitem{Search Target}{
+    \blueitem[Search Target]
 
     \textbf{Initial state for radar returns}
     \begin{itemize}
@@ -122,8 +121,7 @@
     \end{itemize}
 
     Reference \cref{fig:sensorsaa:apg68:tws:trackfile:search}
-    }
-    \blueitem{Track Target}{
+    \blueitem[Track Target]
     
     \textbf{FCR automatically correlates radar return data to form track files}
     \begin{itemize}
@@ -133,8 +131,7 @@
     \end{itemize}
 
     Reference \cref{fig:sensorsaa:apg68:tws:trackfile:track}
-    }
-    \blueitem{System Target}{
+    \blueitem[System Target]
     
     \textbf{Allows pilot to designate targets of interest}
     \begin{itemize}
@@ -144,8 +141,7 @@
     \end{itemize}
 
     Reference \cref{fig:sensorsaa:apg68:tws:trackfile:system}
-    }
-    \blueitem{Cursor Target}{
+    \blueitem[Cursor Target]
         
     \textbf{Acquisition Cursor ``snaps'' to nearby System Targets} --- therefore named Cursor Targets
     \begin{itemize}
@@ -158,8 +154,7 @@
     \end{itemize}
 
     Reference \cref{fig:sensorsaa:apg68:tws:trackfile:cursor,fig:sensorsaa:apg68:tws:cursorsymb}
-    }
-    \blueitem{Bugged Target}{
+    \blueitem[Bugged Target]
         
     \textbf{Selected for weapons employment}
     \begin{itemize}
@@ -176,8 +171,7 @@
     \end{itemize}
 
     Reference \cref{fig:sensorsaa:apg68:tws:trackfile:bugged,fig:sensorsaa:apg68:tws:buggedsymb}
-    }
-    \blueitem{Spotlight}{\textbf{Narrow scan centered on acquisition cursor}
+    \blueitem[Spotlight] \textbf{Narrow scan centered on acquisition cursor}
     \begin{itemize}
         \item \textbf{narrow scan}
         \begin{itemize}
@@ -186,7 +180,7 @@
         \end{itemize}
         \item allows pilot to override TWS scan priority
         \item \textbf{activated by holding TMS Forward >1 sec}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -279,29 +273,27 @@
 
 \subsubsection{SELECT TWS MODE}
 \begin{checklistenumerate}
-    \blueitem{FCR Switch}{\textbf{FCR}}
-    \blueitem{Desired MFD}{\textbf{FCR Page}, verify \textbf{SOI}}
-    \blueitem{Radar Mode}{
-        \textbf{CRM} (default), verify
+    \blueitem[FCR Switch] \textbf{FCR}
+    \blueitem[Desired MFD] \textbf{FCR Page}, verify \textbf{SOI}
+    \blueitem[Radar Mode]
+    \textbf{CRM} (default), verify
 
-        \begin{itemize}
-            \item \textbf{Dogfight/Missile Override} --- \textbf{NORM}
-            \item \textbf{Radar Mode (OSB 1)} --- shows \textbf{CRM}
-        \end{itemize}
-    }
-    \blueitem{CRM Submode}{
-        \textbf{TWS}, cycle via 
+    \begin{itemize}
+        \item \textbf{Dogfight/Missile Override} --- \textbf{NORM}
+        \item \textbf{Radar Mode (OSB 1)} --- shows \textbf{CRM}
+    \end{itemize}
+    \blueitem[CRM Submode]
+    \textbf{TWS}, cycle via 
 
-        \begin{itemize}
-            \item \textbf{TMS Right (long)} / \textbf{OSB 2} 
-        \end{itemize}
-    }
+    \begin{itemize}
+        \item \textbf{TMS Right (long)} / \textbf{OSB 2} 
+    \end{itemize}
 \end{checklistenumerate}
 
 \subsubsection{MULTI-TARGET ACQUISITION}
 \label{subsec:tws:multiacq}
 \begin{checklistenumerate}
-    \blueitem{Track Target Acquisition}{
+    \blueitem[Track Target Acquisition]
     \label{subsec:sensorsaa:apg68:tws:multi:trk}
     \marginpar{
         \captionsetup{type=figure}
@@ -399,8 +391,8 @@
         \end{itemize}
         \item Place targets within radar scan volume
         \item FCR automatically generates Track Targets once sufficient data available
-    \end{enumerate}}
-    \blueitem{System Target Acquisition}{
+    \end{enumerate}
+    \blueitem[System Target Acquisition]
     \label{subsec:sensorsaa:apg68:tws:multi:sys}
     \begin{enumerate}
         \item \textbf{Target} \dotfill under Acquisition Cursor
@@ -410,8 +402,8 @@
     or to upgrade all Track Targets:
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Right}
-    \end{enumerate}}
-    \blueitem{Upgrade to Bugged Target}{
+    \end{enumerate}
+    \blueitem[Upgrade to Bugged Target]
     \label{subsec:sensorsaa:apg68:tws:multi:bug}
     \begin{enumerate}
         \item \textbf{Target} \dotfill under Acquisition Cursor
@@ -424,12 +416,12 @@
     To cycle through System Targets in range order
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Right}
-    \end{enumerate}}
-    \blueitem{STT Lock}{(if desired)
+    \end{enumerate}
+    \blueitem[STT Lock] (if desired)
     \begin{enumerate}
         \item \textbf{Bugged Target} \dotfill under Acq Cursor
         \item \textbf{TMS} \dotfill \textbf{Forward}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/sensors_aa/iff.tex
+++ b/src/chapters/sensors_aa/iff.tex
@@ -2,7 +2,7 @@
 \label{sec:iff}
 
 \begin{tcoloritemize}
-    \blueitem{IFF}{
+    \blueitem[IFF]
     \textbf{I}dentify \textbf{F}riend or \textbf{F}oe
     \begin{itemize}
         \item \textbf{Unknown contacts can be ``interrogated'' to determine if friendly}
@@ -16,8 +16,8 @@
             \item must be powered on separately from FCR to function
         \end{itemize}
         \item \textbf{Friendly IFF replies displayed as green circles on FCR MFD}
-    \end{itemize}}
-    \blueitem{Manual \break Interrogation}{
+    \end{itemize}
+    \blueitem[Manual \break Interrogation]
     Manual IFF interrogation can be initiated in 2 modes
 
     \begin{itemize}
@@ -31,7 +31,7 @@
             \item Actived by pressing \textbf{TMS Left (long)}
             \item \textbf{LOS} appears next to \textbf{OSB 16} on FCR page
         \end{itemize}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \warningbox{
@@ -80,7 +80,7 @@
 
 
 % \begin{tcoloritemize}
-%     \blueitem{Master Switch}{
+%     \blueitem[Master Switch]
 %     Controls operating mode of IFF system when \textbf{C\&I Switch} is set to \textbf{BACKUP}
 
 %     \begin{itemize}
@@ -88,9 +88,8 @@
 %         \item \textbf{STBY} --- system is powered but in standby mode
 %         \item \textbf{NORM} --- normal operating mode
 %     \end{itemize}
-%     }
-%     \blueitem{M-4 Code Switch}{}
-%     \blueitem{C \& I Switch}{
+%     \blueitem[M-4 Code Switch]
+%     \blueitem[C \& I Switch]
 %     Selects source for \textbf{C}ommunications \textbf{\&} \textbf{I}FF control
 
 %     \begin{itemize}
@@ -103,11 +102,11 @@
 %         \begin{itemize}
 %             \item Sets input source as UFC (ICP \& DED) for both IFF and UHF
 %         \end{itemize}
-%     \end{itemize}}
-%     \blueitem{Enable Switch}{}
-%     \blueitem{Mode 1 / 3 Selectors}{}
-%     \blueitem{Mode 4 Reply Switch}{}
-%     \blueitem{Mode 4 Monitor Switch}{}
+%     \end{itemize}
+%     \blueitem[Enable Switch]
+%     \blueitem[Mode 1 / 3 Selectors]
+%     \blueitem[Mode 4 Reply Switch]
+%     \blueitem[Mode 4 Monitor Switch]
 % \end{tcoloritemize}
 
 \marginfigeometry
@@ -115,7 +114,7 @@
 \subsection{INTERROGATION}
 \label{sec:iff:interrogation}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     % \marginpar{
     %     \captionsetup{type=figure}
     %     \fbox{
@@ -139,8 +138,8 @@
     
     \begin{itemize}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
-    \end{itemize}}
-    \blueitem{Locate Targets}{
+    \end{itemize}
+    \blueitem[Locate Targets]
     \begin{enumerate}
         \item Correlate onboard/offboard sensors
         \begin{itemize}
@@ -148,8 +147,8 @@
             \item AWACS calls, datalink targets
         \end{itemize}
         \item Place target within radar scan volume
-    \end{enumerate}}
-    \blueitem{Interrogate}{
+    \end{enumerate}
+    \blueitem[Interrogate]
     % \marginpar{
     %     \captionsetup{type=figure}
     %     \fbox{
@@ -175,13 +174,14 @@
 
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Left (long)}
-    \end{enumerate}}
-    \blueitem{Evaluate Returns}{After 1-3 sec IFF replies should appear
+    \end{enumerate}
+    \blueitem[Evaluate Returns]
+    After 1-3 sec IFF replies should appear
 
     \begin{itemize}
         \item Friendlies are marked by green circles
         \item Depending on avionics and radar mode, radar tracks may be marked in green to indicate friendly
-    \end{itemize}}
+    \end{itemize}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/weapons_aa/gunnery.tex
+++ b/src/chapters/weapons_aa/gunnery.tex
@@ -20,7 +20,7 @@
 % TODO: M61 overview figure!
 
 \begin{tcoloritemize}
-    \blueitem{M-61 Vulcan}{
+    \blueitem[M-61 Vulcan]
     Internally mounted, high fire-rate, 20mm rotary ``Gattling'' cannon.
     In service since 1959
 
@@ -28,16 +28,16 @@
         \item \textbf{Fire Rate} --- 6000rpm
         \item \textbf{Round Size} --- 20mm
         \item \textbf{Ammo Capacity} --- 510 rounds
-    \end{itemize}}
-    \blueitem{Ammunition Types}{
+    \end{itemize}
+    \blueitem[Ammunition Types]
     \begin{itemize}
         \item \textbf{HEI} --- \textbf{H}igh \textbf{E}xplosive \textbf{I}ncendiary
         \item \textbf{HEI-T} --- \textbf{H}igh \textbf{E}xplosive \textbf{I}ncendiary-\textbf{T}racer
         \item \textbf{AP} --- \textbf{A}rmor \textbf{P}iercing
         \item \textbf{TP} --- \textbf{T}arget \textbf{P}ractice
         \item \textbf{SAPHEI} --- \textbf{S}emi \textbf{A}rmor \textbf{P}iercing \textbf{H}igh \textbf{E}xplosive \textbf{I}ncendiary
-    \end{itemize}}
-    \blueitem{Gunsight / \break Cueing Modes}{
+    \end{itemize}
+    \blueitem[Gunsight / \break Cueing Modes]
     \begin{itemize}
         \item \textbf{EEGS} --- \textbf{E}nhanced \textbf{E}nvelope \textbf{G}un\textbf{S}ight \\
         \hyperref[subsec:m61:eegssymb]{see \Cref{subsec:m61:eegssymb}}
@@ -45,8 +45,8 @@
         \hyperref[subsec:m61:eegslvl2]{see \Cref{subsec:m61:eegslvl2}}
         \item \textbf{Employment with radar track (EEGS level V)} \\
         \hyperref[subsec:m61:eegslvl5]{see \Cref{subsec:m61:eegslvl5}}
-    \end{itemize}}
-    \blueitem{Select GUN}{
+    \end{itemize}
+    \blueitem[Select GUN]
     Via Dogfight --- AIM-9 \& GUN automatically selected
 
     \begin{enumerate}
@@ -58,20 +58,23 @@
     \begin{enumerate}
         \item \textbf{Master Mode} \dotfill \textbf{A-A}
         \item \textbf{SMS OSB 1} \dotfill \textbf{Cycle to GUN}
-    \end{enumerate}}
+    \end{enumerate}
 \end{tcoloritemize}
 
 \subsubsection{SMS CONTROLS}
 \label{subsec:m61:sms}
 \begin{tcoloritemize}
-    \blueitem{Operating Mode}{\textbf{OSB 1} cycles A-A modes, should display \textbf{GUN}}
-    \blueitem{Sub-Mode}{\textbf{OSB 2} cycles gunsight modes
+    \blueitem[Operating Mode] 
+    \textbf{OSB 1} cycles A-A modes, should display \textbf{GUN}
+    \blueitem[Sub-Mode]
+    \textbf{OSB 2} cycles gunsight modes
     
     \begin{itemize}
         \item \textbf{EEGS} --- \textbf{E}nhanced \textbf{E}nvelope \textbf{G}un\textbf{S}ight \\
         \textbf{see \Cref{subsec:m61:eegssymb}}
-    \end{itemize}}
-    \blueitem{Rounds \break Remaining}{Indicates number of rounds remaining in 10s}
+    \end{itemize}
+    \blueitem[Rounds \break Remaining]
+    Indicates number of rounds remaining in 10s
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -111,13 +114,15 @@
 \subsubsection{EEGS SYMBOLOGY}
 \label{subsec:m61:eegssymb}
 \begin{tcoloritemize}
-    \blueitem{EEGS}{\textbf{E}nhanced \textbf{E}nvelope \textbf{G}un\textbf{S}ight
+    \blueitem[EEGS] 
+    \textbf{E}nhanced \textbf{E}nvelope \textbf{G}un\textbf{S}ight
 
     \begin{itemize}
         \item \textbf{Provides multiple levels of symbology depending on presence of radar lock}
-    \end{itemize}}
-    \blueitem{Level I}{Backup mode displaying only boresight cross in event of INS failure}
-    \blueitem{Level II}{Operating mode prior to radar lock
+    \end{itemize}
+    \blueitem[Level I] Backup mode displaying only boresight cross in event of INS failure
+    \blueitem[Level II]
+    Operating mode prior to radar lock
 
     \begin{itemize}
         \item \textbf{Boresight Cross} --- shows where gun / aircraft is pointed
@@ -134,9 +139,9 @@
     \end{itemize}
     
     Reference symbology in \cref{fig:aa_weap:m61:eegslvl2}
-    }
-    \blueitem{Level III / IV}{Intermediate modes during radar lock acquisition}
-    \blueitem{Level V}{Operating mode with radar lock. Level II symbology is retained with additional elements
+    \blueitem[Level III / IV] Intermediate modes during radar lock acquisition
+    \blueitem[Level V]
+    Operating mode with radar lock. Level II symbology is retained with additional elements
     
     \begin{itemize}
         \item \textbf{Level V Pipper}
@@ -173,7 +178,6 @@
     \end{itemize}
     
     Reference symbology in \cref{fig:aa_weap:m61:eegslvl5,fig:aa_weap:m61:eegs:5pipper}
-    }
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -328,33 +332,34 @@
 \subsubsection{GUN SELECTION}
 \label{subsec:m61:selection}
 \begin{checklistitemize}
-    \blueitem{Via Dogfight}{(GUN automatically selected)
+    \blueitem[Via Dogfight]
+    (GUN automatically selected)
     \begin{enumerate}
         \item \textbf{DGFT/MSL OVRD} \dotfill \textbf{DGFT}
-    \end{enumerate}}
-    \blueitem{Via A-A Master Mode}{
+    \end{enumerate}
+    \blueitem[Via A-A Master Mode]
     \begin{enumerate}
         \item \textbf{Master Mode} \dotfill \textbf{A-A}
         \item \textbf{SMS OSB 1} \dotfill \textbf{Cycle to GUN}
-    \end{enumerate}}
-    \blueitem{EEGS Symbology}{Verify
+    \end{enumerate}
+    \blueitem[EEGS Symbology] Verify
     \begin{itemize}
         \item \textbf{EEGS Level II} appears if no lock present
         \item \textbf{EEGS Level V} appears if target locked
-    \end{itemize}}
+    \end{itemize}
 \end{checklistitemize}
 
 \subsubsection{EEGS LVL II EMPLOYMENT --- NO RADAR}
 \label{subsec:m61:eegslvl2}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{RF Switch} \dotfill \textbf{SILENT} \\
         \hfill (if desired, completely silences radar)
         \item \textbf{Selected Weapon} \dotfill \textbf{GUN}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{Acquire Firing Solution}{
+    \end{itemize}
+    \blueitem[Acquire Firing Solution]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -381,12 +386,12 @@
     
     \begin{enumerate}
         \item \textbf{MGRS Line} \dotfill \textbf{Aligned with target}
-    \end{enumerate}}
-    \blueitem{Fire Gun}{
+    \end{enumerate}
+    \blueitem[Fire Gun]
     \begin{enumerate}
         \item \textbf{TRIGGER} \dotfill \textbf{2nd Detent}
         \item Adjust lead to achieve desired effects
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 % \notebox{
@@ -405,20 +410,21 @@
 \subsubsection{EEGS LVL V EMPLOYMENT --- RADAR}
 \label{subsec:m61:eegslvl5}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{RF Switch} \dotfill \textbf{NORM}
         \item \textbf{Selected Weapon} \dotfill \textbf{GUN}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{Radar Acquisition}{ACM selected automatically in \textbf{DGFT} mode, \textbf{see \Cref{subsec:acm}}
+    \end{itemize}
+    \blueitem[Radar Acquisition]
+    ACM selected automatically in \textbf{DGFT} mode, \textbf{see \Cref{subsec:acm}}
 
     \begin{enumerate}
         \item \textbf{ACM Submode} \dotfill \textbf{As desired}
         \item Maneuver to place target in radar scan volume
-    \end{enumerate}}
-    \blueitem{Acquire Firing Solution}{
+    \end{enumerate}
+    \blueitem[Acquire Firing Solution]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -433,28 +439,28 @@
     }
     \begin{enumerate}
         \item \textbf{Pipper} \dotfill \textbf{Stabilized On-Target}
-    \end{enumerate}}
-    \blueitem{Fire Gun}{
+    \end{enumerate}
+    \blueitem[Fire Gun]
     \begin{enumerate}
         \item \textbf{TRIGGER} \dotfill \textbf{2nd Detent}
         \item Adjust lead to achieve desired effects
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \subsubsection{ADJUST EEGS FUNNEL WIDTH}
 \label{subsec:m61:eegsfunneladjust}
 \begin{checklistenumerate}
-    \blueitem{Open DED MAN Page}{
+    \blueitem[Open DED MAN Page]
     \begin{enumerate}
         \item \textbf{ICP LIST Button} \dotfill \textbf{Press}
         \item \textbf{DED MAN Page} \dotfill \textbf{Open (5)} 
-    \end{enumerate}}
-    \blueitem{Adjust Wingspan}{
+    \end{enumerate}
+    \blueitem[Adjust Wingspan]
     \begin{enumerate}
         \item \textbf{WSPAN} \dotfill \textbf{Selected}
         \item \textbf{Desired Value} \dotfill Input on ICP, \textbf{ENTR}
         \item \textbf{WSPAN} \dotfill Verify as desired
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/weapons_aa/missiles.tex
+++ b/src/chapters/weapons_aa/missiles.tex
@@ -98,7 +98,7 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{AIM-120 \break Employment \break Profile}{
+    \blueitem[AIM-120 \break Employment \break Profile]
     \Cref{fig:aa_weap:bvr:aim120profile} shows the trajectories of fighter, bandit \& missile for a generic AIM-120 employment profile
     including the following phases
 
@@ -107,8 +107,8 @@
         \item \textbf{B --- Mid-Course Phase}
         \item \textbf{C --- Acquisition}
         \item \textbf{D --- Intercept}
-    \end{itemize}}
-    \blueitem{Launch / Boost Phase}{
+    \end{itemize}
+    \blueitem[Launch / Boost Phase]
     \textbf{Boost}
 
     \begin{itemize}
@@ -122,26 +122,25 @@
         \item To reach longer ranges missile ``lofts'' itself to conserve energy \& optimize trajectory
         \item Pilot can manually loft by raising the nose 20-30 deg prior to launch
     \end{itemize}
-    }
-    \blueitem{Mid-Course Phase}{
+    \blueitem[Mid-Course Phase]
     \textbf{Missile flies using internal IMU}
 
     \begin{itemize}
         \item Receives periodic datalink updates
         \item Will fly to last updated target position if DL lost
-    \end{itemize}}
-    \blueitem{Acquisition \& MPRF ``Active'' Phase}{
+    \end{itemize}
+    \blueitem[Acquisition \& MPRF ``Active'' Phase]
     \textbf{Missile radar turns on once close to target location}
     \begin{itemize}
         \item Seeker in MPRF (Medium Pulse Repetition Frequency) mode 
         \item Locks on to closest / best target
-    \end{itemize}}
-    \blueitem{Terminal Phase \& Intercept}{
+    \end{itemize}
+    \blueitem[Terminal Phase \& Intercept]
     \textbf{Once missile seeker has acquired target}
     \begin{itemize}
         \item Flies PNG intercept trajectory
         \item Requires no further DL support, fighter can turn away from the bandit
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \warningbox{
@@ -152,7 +151,7 @@
 \label{subsec:bvr:tacticalconsideration}
 % \label{subsec:aim120:tactics}
 \begin{tcoloritemize}
-    \blueitem{Range Definitions}{
+    \blueitem[Range Definitions]
     \textbf{Fighter-bandit distance} can be measured at different points during the timeline
 
     \begin{itemize}
@@ -162,8 +161,7 @@
     \end{itemize}
     
     These are also illustrated in \cref{fig:aa_weap:bvr:aim120profile}.
-    }
-    \blueitem{Maximizing Launch Range / Energy}{
+    \blueitem[Maximizing Launch Range / Energy]
     \textbf{Why?}
     \begin{itemize}
         \item Ability to launch at longer ranges forces bandit defensive
@@ -174,8 +172,8 @@
     \begin{itemize}
         \item \textbf{High velocity} --- increases kinetic energy 
         \item \textbf{High altitude} --- increases potential energy, reduces drag
-    \end{itemize}}
-    \blueitem{Maximizing \break F-Pole Range}{
+    \end{itemize}
+    \blueitem[Maximizing \break F-Pole Range]
     \textbf{Why?}
     \begin{itemize}
         \item Less likely to enter bandit launch envelope
@@ -185,8 +183,8 @@
     \begin{itemize}
         \item \textbf{Crank} --- turn 45-60 degrees away from bandit to reduce closure rate, maintain radar contact
         \item \textbf{Dive} --- reduces threat missile envelope
-    \end{itemize}}
-    \blueitem{Flowing Cold}{
+    \end{itemize}
+    \blueitem[Flowing Cold]
     \textbf{Why?}
     \begin{itemize}
         \item Missile requires no support once active
@@ -197,15 +195,15 @@
     \begin{itemize}
         \item \textbf{Turn} --- Away from bandit / threat
         \item \textbf{Dive} --- if necessary, reduces threat missile envelope 
-    \end{itemize}}
-    \blueitem{Effect of Bandit Maneuvers}{
+    \end{itemize}
+    \blueitem[Effect of Bandit Maneuvers]
     As evident in \cref{fig:aa_weap:bvr:aim120profile}, 
    \textbf{R\textsubscript{Launch}} is significantly greater than the distance travelled by the missile
     \begin{itemize}
         \item \textbf{DLZ calculated based off \underline{both} fighter \underline{and} bandit velocity/altitude}
         \item Bandit can significantly change missile envelope by reducing closure rate / altitude
         \item Post-launch bandit maneuvers can result in missile not having energy to intercept
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \clearpage
@@ -213,7 +211,8 @@
 \subsubsection{FIGHTER MANEUVERS}
 
 \begin{tcoloritemize}
-    \blueitem{Crank}{Fighter turns \textbf{45-60 deg} away from threat 
+    \blueitem[Crank]
+    Fighter turns \textbf{45-60 deg} away from threat 
 
     \begin{itemize}
         \item reduces closure while maintaining radar track
@@ -221,8 +220,8 @@
     \end{itemize}
     
     Reference \cref{fig:aa_weap:bvr:fightermaneuver:crank}
-    }
-    \blueitem{Notch}{Fighter turns \textbf{70-110 deg} away from threat
+    \blueitem[Notch]
+    Fighter turns \textbf{70-110 deg} away from threat
 
     \begin{itemize}
         \item minimizes relative velocity to break hostile pulse-doppler radar track
@@ -230,14 +229,14 @@
     \end{itemize}
     
     Reference \cref{fig:aa_weap:bvr:fightermaneuver:notch}
-    }
-    \blueitem{Go Cold}{Fighter turns \textbf{away} from threat
+    \blueitem[Go Cold]
+    Fighter turns \textbf{away} from threat
 
     \begin{itemize}
         \item used to kinematically defeat threat missiles
     \end{itemize}
     
-    Reference \cref{fig:aa_weap:bvr:fightermaneuver:cold}}
+    Reference \cref{fig:aa_weap:bvr:fightermaneuver:cold}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -352,24 +351,29 @@
 \subsubsection{TARGET ASPECT}
 
 \begin{tcoloritemize}
-    \blueitem{Target Aspect}{Angle between imaginary line connecting fighter-bandit and bandit heading}
-    \blueitem{Hot}{\textbf{Target aspect --- 0-40 deg}
+    \blueitem[Target Aspect]
+    Angle between imaginary line connecting fighter-bandit and bandit heading
+    \blueitem[Hot]
+    \textbf{Target aspect --- 0-40 deg}
     \begin{itemize}
         \item offensive posture, maximizes closure
-    \end{itemize}}
-    \blueitem{Flank}{\textbf{Target aspect --- 40-70 deg}
+    \end{itemize}
+    \blueitem[Flank]
+    \textbf{Target aspect --- 40-70 deg}
     \begin{itemize}
         \item minimizes closure while maintaining radar track
-    \end{itemize} }
-    \blueitem{Beam}{\textbf{Target aspect --- 70-110 deg}
+    \end{itemize}
+    \blueitem[Beam]
+    \textbf{Target aspect --- 70-110 deg}
     \begin{itemize}
         \item defensive maneuver to break pulse-doppler radar track
-    \end{itemize}}
-    \blueitem{Drag}{\textbf{Target aspect --- 110-180 deg}
+    \end{itemize}
+    \blueitem[Drag]
+    \textbf{Target aspect --- 110-180 deg}
     \begin{itemize}
         \item defense to kinematically defeat missile
         \item often used in group tactics as ambush setup
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]

--- a/src/chapters/weapons_aa/missiles/aim120.tex
+++ b/src/chapters/weapons_aa/missiles/aim120.tex
@@ -587,7 +587,7 @@
         \item \textbf{IFF Returns} \dotfill \textbf{None} (near target)
         \item \textbf{NCTR ID} \dotfill \textbf{Hostile} (if available)
     \end{enumerate}
-    \blueitem[Fire Missile]{
+    \blueitem[Fire Missile]
     \marginpar{
         \captionsetup{type=figure}
         \begin{tikzpicture}[figstyle]
@@ -603,7 +603,7 @@
         \item \textbf{ASC} \dotfill within \textbf{ASEC}
         \item \textbf{DLZ} \dotfill indicates \textbf{In-Range}
         \item \textbf{WPN REL} \dotfill \textbf{Depress}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage

--- a/src/chapters/weapons_aa/missiles/aim120.tex
+++ b/src/chapters/weapons_aa/missiles/aim120.tex
@@ -10,15 +10,15 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{AIM-120 \break AMRAAM}{
+    \blueitem[AIM-120 \break AMRAAM]
     \textbf{A}dvanced \textbf{M}edium \textbf{R}ange \textbf{A}ir-to-\textbf{A}ir \textbf{M}issile
     --- long range, fire-and-forget, active-radar homing missile
 
     \begin{itemize}
         \item \textbf{Guidance} --- Active Radar-Guided (\textbf{Fox 3})
         \item \textbf{Range} --- max:  \textasciitilde30-40nm (high mach, alt)
-    \end{itemize}}
-    \blueitem{Employment \break Types}{
+    \end{itemize}
+    \blueitem[Employment \break Types]
     \begin{itemize}
         \item \textbf{Maddog / Active Launch  (no radar)} \\
         \hyperref[subsec:aim120:maddog]{see \Cref{subsec:aim120:maddog}}
@@ -26,16 +26,16 @@
         \hyperref[subsec:aim120:single]{see \Cref{subsec:aim120:single}}
         \item \textbf{Multi-target employment (TWS/DTT bug)} \\
         \hyperref[subsec:aim120:multi]{see \Cref{subsec:aim120:multi}}
-    \end{itemize}}
-    \blueitem{Flight Profile}{Successful long-range weapon employment necessitates understanding of flight-profile and tactics
+    \end{itemize}
+    \blueitem[Flight Profile]
+    Successful long-range weapon employment necessitates understanding of flight-profile and tactics
     \begin{itemize}
         \item \textbf{Mid-Course} --- Guided via \underline{datalink}, launching fighter should maintain radar contact with target
         \item \textbf{Terminal Phase} --- Guided via \underline{internal radar}, launching fighter may break away
     \end{itemize}
     
     \textbf{See \Cref{subsec:bvr} and \Cref{subsec:bvr:tacticalconsideration}}
-    }
-    \blueitem{Select AIM-120}{
+    \blueitem[Select AIM-120]
     Via A-A Master Mode
 
     \begin{enumerate}
@@ -59,25 +59,23 @@
     \end{enumerate}
     
     Selected weapon can also be cycled with \textbf{NWS/MSL Step depress (long)}
-    }
 \end{tcoloritemize}
 
 \subsubsection{SMS CONTROLS}
 \label{subsec:aim120:sms}
 \begin{tcoloritemize}
-    \blueitem{Selected Weapon}{
+    \blueitem[Selected Weapon]
     \textbf{OSB 7} cycles through available A-A weapon types
     
     \medskip
     Selected weapon can also be cycled with \textbf{NWS/MSL Step depress (long)}
-    }
-    \blueitem{Selected Station}{
+    \blueitem[Selected Station]
     \textbf{OSB 10 / 16} select/cycle availabel missile pylons
     
     \medskip
     Selected station can also be cycled with \textbf{NWS/MSL Step depress (short)}
-    }
-    \blueitem{SLAVE / BORE}{\textbf{OSB 19} controls missile radar line-of-sight
+    \blueitem[SLAVE / BORE]
+    \textbf{OSB 19} controls missile radar line-of-sight
     \begin{itemize}
         \item \textbf{SLAVE} --- Missile LOS slaved to AC radar 
         \begin{itemize}
@@ -89,7 +87,7 @@
         \end{itemize}
     \end{itemize}
     
-    Line-of-sight mode can also be cycled with \textbf{Cursor Enable Depress}}
+    Line-of-sight mode can also be cycled with \textbf{Cursor Enable Depress}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -135,8 +133,10 @@
 \label{subsec:aim120:symb}
 
 \begin{tcoloritemize}
-    \blueitem{Basic Radar Symbology}{For beyond-visual-range radar usage and symbology \textbf{reference \Crefrange{subsec:crm}{subsec:tws}}}
-    \blueitem{DLZ}{\textbf{D}ynamic \textbf{L}aunch \textbf{Z}one
+    \blueitem[Basic Radar Symbology] 
+    For beyond-visual-range radar usage and symbology \textbf{reference \Crefrange{subsec:crm}{subsec:tws}}
+    \blueitem[DLZ]
+    \textbf{D}ynamic \textbf{L}aunch \textbf{Z}one
     \begin{itemize}
         \item \textbf{Displays target range \& missile performance information on HUD \& FCR Page with}
         \begin{itemize}
@@ -166,8 +166,8 @@
             \item \textbf{T} --- seconds until predicted impact
         \end{itemize}
     \end{itemize}
-    Reference \cref{fig:aa_weap:aim120:dlz}}
-    \blueitem{ASC \& ASEC}{
+    Reference \cref{fig:aa_weap:aim120:dlz}
+    \blueitem[ASC \& ASEC]
     \begin{itemize}
         \item \textbf{Displays target lead cues to maximize missile performance on HUD \& FCR Page with}
         \begin{itemize}
@@ -181,7 +181,7 @@
             \item dynamically adjusts size based on target maneuvers
             \item fixed size prior to target designation
         \end{itemize}
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 % \clearpage
@@ -311,22 +311,24 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{Designator Box}{Box around target when within HUD view}
-    \blueitem{TLL}{\textbf{T}arget \textbf{L}ocator \textbf{L}ine
+    \blueitem[Designator Box] Box around target when within HUD view
+    \blueitem[TLL]
+    \textbf{T}arget \textbf{L}ocator \textbf{L}ine
     
     \begin{itemize}
         \item \textbf{Extends from boresight cross towards target}
         \item \textbf{Relative angle displayed next to boresight cross}
         \item \textbf{Displayed when target is not within HUD field-of-view}
-    \end{itemize}}
-    \blueitem{Missile Diamond}{Indicates missile seeker line-of-sight}
-    \blueitem{Post-Launch Symbology}{Bugged track symbology is modified to reflect missile launch \& status
+    \end{itemize}
+    \blueitem[Missile Diamond] Indicates missile seeker line-of-sight
+    \blueitem[Post-Launch Symbology]
+    Bugged track symbology is modified to reflect missile launch \& status
 
     \begin{itemize}
         \item \textbf{Post-launch} --- Thick ``tail'' is added
         \item \textbf{Post-active} --- Tail begins to flash
         \item \textbf{Post predicted impact} --- Red cross flashes over track
-    \end{itemize}}
+    \end{itemize}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -449,7 +451,7 @@
 \subsubsection{AIM-120 SELECTION}
 \label{subsec:aim120:selection}
 \begin{checklistitemize}
-    \blueitem{Via A-A Master Mode}{
+    \blueitem[Via A-A Master Mode]
     \begin{enumerate}
         \item \textbf{Master Mode} \dotfill \textbf{A-A}
         \item \textbf{SMS OSB 1} \dotfill Verify \textbf{AAM}
@@ -458,8 +460,8 @@
             \item \textbf{SMS OSB 7} --- \textbf{Press}
             \item or \textbf{NWS/MSL STEP} --- \textbf{Press (long)}
         \end{itemize}
-    \end{enumerate}}
-    \blueitem{Via MSL OVRD}{
+    \end{enumerate}
+    \blueitem[Via MSL OVRD]
     \begin{enumerate}
         \item \textbf{DGFT/MSL OVRD} \dotfill \textbf{OVRD}
         \item \textbf{Selected Weapon} \dotfill Verify \textbf{120C} 
@@ -467,8 +469,8 @@
             \item \textbf{SMS OSB 7} --- \textbf{Press}
             \item or \textbf{NWS/MSL STEP} --- \textbf{Press (long)}
         \end{itemize}
-    \end{enumerate}}
-    \blueitem{Via DGFT}{
+    \end{enumerate}
+    \blueitem[Via DGFT]
     \begin{enumerate}
         \item \textbf{DGFT/MSL OVRD} \dotfill \textbf{DGFT}
         \item \textbf{Selected Weapon} \dotfill \textbf{120C}
@@ -476,13 +478,13 @@
             \item \textbf{SMS OSB 7} --- \textbf{Press}
             \item or \textbf{NWS/MSL STEP} --- \textbf{Press (long)}
         \end{itemize}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistitemize}
 
 \subsubsection{MADDOG EMPLOYMENT --- NO RADAR}
 \label{subsec:aim120:maddog}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{RF Switch} \dotfill \textbf{SILENT} \\
         \hfill (if desired, completely silences radar)
@@ -493,17 +495,17 @@
             \item or \textbf{Cursor Enable} --- \textbf{Press}
         \end{itemize}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{Target Acquisition}{ 
+    \end{itemize}
+    \blueitem[Target Acquisition]
     \begin{enumerate}
         \item Maneuver to place target within ASEC
-    \end{enumerate}}
-    \blueitem{Fire Missile}{
+    \end{enumerate}
+    \blueitem[Fire Missile]
     \begin{enumerate}
         \item Verify area clear of friendly aircraft
         \item \textbf{WPN REL} \dotfill \textbf{Depress}
         \item Observe missile and prepare to delete HUD tape in case of court martial
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
@@ -511,7 +513,7 @@
 \subsubsection{SINGLE-TARGET EMPLOYMENT}
 \label{subsec:aim120:single}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{Desired MFD} \dotfill \textbf{FCR Page (SOI)}
@@ -519,15 +521,15 @@
         \item \textbf{Selected Weapon} \dotfill \textbf{120C}
         \item \textbf{SLAVE/BORE} \dotfill Verify \textbf{SLAVE}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{CRM Submode}{\textbf{As Desired}
+    \end{itemize}
+    \blueitem[CRM Submode] \textbf{As Desired}
     \begin{itemize}
         \item \textbf{RWS} --- fast, long-range search mode \\
         \textbf{see \Cref{subsec:rws}}
         \item \textbf{TWS} --- multi-target track mode \\
         \textbf{see \Cref{subsec:tws}}
-    \end{itemize}}
-    \blueitem{Radar Acquisition}{%
+    \end{itemize}
+    \blueitem[Radar Acquisition]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -563,8 +565,8 @@
     \begin{enumerate}[start=4]
         \item \textbf{TMS} \dotfill \textbf{Forward}
         \item \textbf{Target} \dotfill verify \textbf{Locked}
-    \end{enumerate}}
-    \blueitem{LOS IFF}{%
+    \end{enumerate}
+    \blueitem[LOS IFF]
     % \marginpar{
     %     \captionsetup{type=figure}
     %     \fbox{
@@ -584,8 +586,8 @@
         \item \textbf{TMS} \dotfill \textbf{Left (long)}
         \item \textbf{IFF Returns} \dotfill \textbf{None} (near target)
         \item \textbf{NCTR ID} \dotfill \textbf{Hostile} (if available)
-    \end{enumerate}}
-    \blueitem{Fire Missile}{
+    \end{enumerate}
+    \blueitem[Fire Missile]{
     \marginpar{
         \captionsetup{type=figure}
         \begin{tikzpicture}[figstyle]
@@ -610,7 +612,7 @@
 \label{subsec:aim120:multi}
 
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{Desired MFD} \dotfill \textbf{FCR Page (SOI)}
@@ -618,15 +620,16 @@
         \item \textbf{Selected Weapon} \dotfill \textbf{120C}
         \item \textbf{SLAVE/BORE} \dotfill Verify \textbf{SLAVE}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{CRM Submode}{\textbf{As Desired}
+    \end{itemize}
+    \blueitem[CRM Submode] \textbf{As Desired}
     \begin{itemize}
         \item \textbf{RWS} --- max 2-target engagement (DTT) \\
         \textbf{See \Cref{subsec:rws}}
         \item \textbf{TWS} --- true multi-target capability \\
         \textbf{See \Cref{subsec:tws}}
-    \end{itemize}}
-    \blueitem{Track Acquisition}{For demonstration we will use \textbf{CRM-TWS Submode} 
+    \end{itemize}
+    \blueitem[Track Acquisition]
+    For demonstration we will use \textbf{CRM-TWS Submode} 
     \marginpar{
         \captionsetup{type=figure}
         \begin{tikzpicture}[figstyle]
@@ -740,29 +743,29 @@
 
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Right}
-    \end{enumerate}}
-    \blueitem{SCAN IFF}{\textbf{See \Cref{sec:iff}}
+    \end{enumerate}
+    \blueitem[SCAN IFF]
+    \textbf{See \Cref{sec:iff}}
 
     \begin{enumerate}
         \item \textbf{TMS} \dotfill \textbf{Left (short)}
         \item \textbf{IFF Returns} \dotfill \textbf{None} (near tracks)
-    \end{enumerate}}
-    \blueitem{Bug Acquisition}{
+    \end{enumerate}
+    \blueitem[Bug Acquisition]
     \begin{enumerate}
         \item \label{subsec:aim120:multi:acq}\textbf{Target} \dotfill under \textbf{Acquisition cursor}
         \item \label{subsec:aim120:multi:tmsfwd}\textbf{TMS} \dotfill \textbf{Forward}
         \item \textbf{Target} \dotfill verify \textbf{Bugged}
     \end{enumerate}
     
-    Can cycle bugged target with \textbf{TMS Right}}
-    \blueitem{Fire Missile}{
+    Can cycle bugged target with \textbf{TMS Right}
+    \blueitem[Fire Missile]
     \begin{enumerate}
         \item \textbf{ASC} \dotfill within \textbf{ASEC}
         \item \textbf{DLZ} \dotfill indicates \textbf{In-Range}
         \item \label{subsec:aim120:multi:wpnrel}\textbf{WPN REL} \dotfill \textbf{Depress}
     \end{enumerate}
     Repeat \crefrange{subsec:aim120:multi:acq}{subsec:aim120:multi:wpnrel} for desired targets
-    }
 \end{checklistenumerate}
 
 \marginfigrestore

--- a/src/chapters/weapons_aa/missiles/aim9.tex
+++ b/src/chapters/weapons_aa/missiles/aim9.tex
@@ -32,19 +32,19 @@
 \end{figure}
 
 \begin{tcoloritemize}
-    \blueitem{AIM-9 \break Sidewinder}{
+    \blueitem[AIM-9 \break Sidewinder]
     Short-range, fire-and-forget ``dogfight'' missile. First entered service in 1956
 
     \begin{itemize}
         \item \textbf{Guidance} --- IR-guided (\textbf{Fox 2})
         \item \textbf{Range} --- min: \textasciitilde3000ft, max: \textasciitilde10-20nm
-    \end{itemize}}
-    \blueitem{Variants}{
+    \end{itemize}
+    \blueitem[Variants]
     \begin{itemize}
         \item \textbf{9M} --- IR-guided, short range, all-aspect
         \item \textbf{9X} --- HOBS (\textbf{H}igh \textbf{O}ff-\textbf{B}ore\textbf{S}ight) capable, thrust-vectored, all-aspect
-    \end{itemize}}
-    \blueitem{Acquisition / Cueing Modes}{
+    \end{itemize}
+    \blueitem[Acquisition / Cueing Modes]
     \begin{itemize}
         \item \textbf{Acquisition with own missile seeker (BORE)} \\
         \hyperref[subsec:aim9:bore]{see \Cref{subsec:aim9:bore}}
@@ -52,8 +52,8 @@
         {see \Cref{subsec:aim9:hmcs}}
         \item \textbf{Seeker slaved to radar track LOS (SLAVE)} \\
         \hyperref[subsec:aim9:slave]{see \Cref{subsec:aim9:slave}}
-    \end{itemize}}
-    \blueitem{Select AIM-9}{
+    \end{itemize}
+    \blueitem[Select AIM-9]
     Via Dogfight --- AIM-9 \& GUN automatically selected
 
     \begin{enumerate}
@@ -77,38 +77,35 @@
     \end{enumerate}
     
     Selected weapon can also be cycled with \textbf{NWS/MSL Step depress (long)}
-    }
 \end{tcoloritemize}
     
 \subsubsection{SMS CONTROLS}
 
 \begin{tcoloritemize}
-    \blueitem{SPOT / SCAN}{
+    \blueitem[SPOT / SCAN]
     \textbf{OSB 2} controls seeker field of view
     \begin{itemize}
         \item \textbf{SPOT} --- Narrow, increased detection range
         \item \textbf{SCAN} --- Wide, decreased detection range
-    \end{itemize}}
-    \blueitem{Selected Weapon}{
+    \end{itemize}
+    \blueitem[Selected Weapon]
     \textbf{OSB 7} cycles through available A-A weapon types
     
     \medskip
     Selected weapon can also be cycled with \textbf{NWS/MSL Step depress (long)}
-    }
-    \blueitem{WARM / COOL}{
+    \blueitem[WARM / COOL]
     \textbf{OSB 8} controls seeker cooling status
 
     \begin{itemize}
         \item \textbf{COOL} ---  increases seeker sensitivity, should be set prior to engagement
         \item Set automatically for \textbf{DGFT} \& \textbf{MSL OVRD}
-    \end{itemize}}
-    \blueitem{Selected Station}{
+    \end{itemize}
+    \blueitem[Selected Station]
     \textbf{OSB 10 / 16} select/cycle available missile pylons
     
     \medskip
     Selected station can also be cycled with \textbf{NWS/MSL Step depress (short)}
-    }
-    \blueitem{SLAVE / BORE}{
+    \blueitem[SLAVE / BORE]
     \textbf{OSB 19} controls seeker line-of-sight
 
     \begin{itemize}
@@ -125,7 +122,7 @@
         \end{itemize}
     \end{itemize}
     
-    Line-of-sight mode can also be cycled with \textbf{Cursor Enable Depress}}
+    Line-of-sight mode can also be cycled with \textbf{Cursor Enable Depress}
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -173,8 +170,8 @@
 
 \subsubsection{SYMBOLOGY}
 \begin{tcoloritemize}
-    \blueitem{MFD Symbology}{Reference \Cref{subsec:aim120:symb}}
-    \blueitem{HUD/HMD \break Symbology}{
+    \blueitem[MFD Symbology] Reference \Cref{subsec:aim120:symb}
+    \blueitem[HUD/HMD \break Symbology]
     \begin{itemize}
         \item \textbf{Missile Diamond} --- AIM-9 seeker line-of-sight
         \begin{itemize}
@@ -198,7 +195,6 @@
             \item reference \Cref{subsec:aim120:symb}
         \end{itemize}
     \end{itemize}
-    }
 \end{tcoloritemize}
 
 \begin{figure}[htbp]
@@ -281,11 +277,12 @@
 
 \subsubsection{AIM-9 SELECTION}
 \begin{checklistitemize}
-    \blueitem{Via DGFT}{(AIM-9 selected automatically)
+    \blueitem[Via DGFT] 
+    (AIM-9 selected automatically)
     \begin{enumerate}
         \item \textbf{DGFT/MSL OVRD} \dotfill \textbf{DGFT}
-    \end{enumerate}}
-    \blueitem{Via MSL OVRD}{
+    \end{enumerate}
+    \blueitem[Via MSL OVRD]
     \begin{enumerate}
         \item \textbf{DGFT/MSL OVRD} \dotfill \textbf{MSL OVRD}
         \item \textbf{Selected Weapon} \dotfill \textbf{9M/9X}
@@ -293,8 +290,8 @@
             \item \textbf{SMS OSB 7} --- \textbf{Press}
             \item or \textbf{NWS/MSL STEP} --- \textbf{Press (long)}
         \end{itemize}
-    \end{enumerate}}
-    \blueitem{Via A-A Master Mode}{
+    \end{enumerate}
+    \blueitem[Via A-A Master Mode]
     \begin{enumerate}
         \item \textbf{Master Mode} \dotfill \textbf{A-A}
         \item \textbf{SMS OSB 1} \dotfill \textbf{Verify AAM} (default)
@@ -303,13 +300,13 @@
             \item \textbf{SMS OSB 7} --- \textbf{Press}
             \item or \textbf{NWS/MSL STEP} --- \textbf{Press (long)}
         \end{itemize}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistitemize}
 
 \subsubsection{BORE EMPLOYMENT --- NO RADAR}
 \label{subsec:aim9:bore}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{RF Switch} \dotfill \textbf{SILENT} \\
         \hfill (if desired, completely silences radar)
@@ -317,8 +314,8 @@
         \item \textbf{SLAVE/BORE} \dotfill \textbf{BORE}
         \item \textbf{WARM/COOL} \dotfill Verify \textbf{COOL}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{AIM-9 Track Acquisition}{
+    \end{itemize}
+    \blueitem[AIM-9 Track Acquisition]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -336,13 +333,13 @@
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{CAGE/UNCAGE} \dotfill \textbf{Press}
         \item \textbf{Missile Diamond} \dotfill verify latched to target
-    \end{enumerate}}
-    \blueitem{Fire Missile}{
+    \end{enumerate}
+    \blueitem[Fire Missile]
     \begin{enumerate}
         \item Maneuver into firing position
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{WPN REL} \dotfill \textbf{Depress}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
@@ -350,7 +347,7 @@
 \subsubsection{HMCS BORE EMPLOYMENT --- NO RADAR}
 \label{subsec:aim9:hmcs}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{HMD SYMB. INT} \dotfill \textbf{INT}
         \item \textbf{RF Switch} \dotfill \textbf{SILENT} \\
@@ -359,8 +356,8 @@
         \item \textbf{SLAVE/BORE} \dotfill \textbf{BORE}
         \item \textbf{WARM/COOL} \dotfill Verify \textbf{COOL}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{AIM-9 Track Acquisition}{
+    \end{itemize}
+    \blueitem[AIM-9 Track Acquisition]
     \marginpar{
         \captionsetup{type=figure}
         \begin{tikzpicture}[figstyle]
@@ -405,13 +402,13 @@
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{CAGE/UNCAGE} \dotfill \textbf{Press}
         \item \textbf{Missile Diamond} \dotfill verify latched to target
-    \end{enumerate}}
-    \blueitem{Fire Missile}{
+    \end{enumerate}
+    \blueitem[Fire Missile]
     \begin{enumerate}
         \item Maneuver into firing position
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{WPN REL} \dotfill \textbf{Depress}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \clearpage
@@ -419,7 +416,7 @@
 \subsubsection{SLAVE EMPLOYMENT --- RADAR}
 \label{subsec:aim9:slave}
 \begin{checklistenumerate}
-    \blueitem{Prerequisites}{
+    \blueitem[Prerequisites]
     \begin{itemize}
         \item \textbf{FCR Switch} \dotfill \textbf{FCR}
         \item \textbf{RF Switch} \dotfill \textbf{NORM}
@@ -428,8 +425,9 @@
         \item \textbf{SLAVE/BORE} \dotfill Verify \textbf{SLAVE}
         \item \textbf{WARM/COOL} \dotfill Verify \textbf{COOL}
         \item \textbf{Master Arm} \dotfill \textbf{ARM}
-    \end{itemize}}
-    \blueitem{Radar Acquisition}{ACM selected automatically in \textbf{DGFT} mode, \textbf{see \Cref{subsec:acm}}
+    \end{itemize}
+    \blueitem[Radar Acquisition]
+    ACM selected automatically in \textbf{DGFT} mode, \textbf{see \Cref{subsec:acm}}
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -458,8 +456,7 @@
     \end{enumerate}
     
     Can also lock from CRM, \textbf{see \Cref{subsec:crm}}
-    }
-    \blueitem{AIM-9 Track Acquisition}{
+    \blueitem[AIM-9 Track Acquisition]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -476,8 +473,8 @@
         \item \textbf{CAGE/UNCAGE} \dotfill \textbf{Press}
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{Missile Diamond} \dotfill verify latched to target
-    \end{enumerate}}
-    \blueitem{Fire Missile}{
+    \end{enumerate}
+    \blueitem[Fire Missile]
     \marginpar{
         \captionsetup{type=figure}
         \centering
@@ -495,7 +492,7 @@
         \item \textbf{DLZ} \dotfill indicates \textbf{In-Range}
         \item \textbf{Sidewinder Audio} \dotfill \textbf{Lock Tone}
         \item \textbf{WPN REL} \dotfill \textbf{Depress}
-    \end{enumerate}}
+    \end{enumerate}
 \end{checklistenumerate}
 
 \marginfigrestore 

--- a/src/technumitem.sty
+++ b/src/technumitem.sty
@@ -24,9 +24,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{technumitem}[2024/01/23]
 
-\RequirePackage{booktabs} % fancy tables
-\RequirePackage{multirow} % more fancy tables
-\RequirePackage{longtable} % multi page tables
+\RequirePackage{enumitem} % better enumerate/itemize formatting
 
 \RequirePackage{tcolorbox} % for rounded boxes
 \tcbuselibrary{skins, breakable}
@@ -58,17 +56,16 @@
 \newcounter{checklistnumistart} % used to check if first line to prevent
 
 % Key to start an enumerate at a given number
-\define@key{checklistnumitem}{start}{
-	\setcounter{checklistnumi}{#1}
-	\setcounter{checklistnumistart}{\value{tcolornumi}}
+\define@key{checklistnumitem}{start}{%
+	\setcounter{checklistnumi}{#1}%
+	\setcounter{checklistnumistart}{\value{tcolornumi}}%
 }
 
 % Key to resume an enumerate at previous number
-\define@key{checklistnumitem}{resume}[]{
-	\setcounter{checklistnumistart}{\value{tcolornumi}}
+\define@key{checklistnumitem}{resume}[]{%
+	\setcounter{checklistnumistart}{\value{tcolornumi}}%
 }
 
-% SHORT VERSIONS
 \newenvironment{checklistenumerate}[1][start=1]{% begdef
     \setkeys{checklistnumitem}{#1}%
 	\newcommand{\blueitem}[1][]{%
@@ -103,7 +100,6 @@
     breakable,
     colback=white,
     colframe=color1,
-    % sharp corners=north,
     colbacktitle=color1,
     coltitle=white,
     left=0mm,
@@ -128,7 +124,6 @@
     nobeforeafter,
     colback=white,
     colframe=color1,
-    % sharp corners,
     boxrule=0.5mm,
     colbacktitle=color1,
     coltitle=white,
@@ -164,14 +159,14 @@
 \newcounter{tcolornumistart} % used to check if first line to prevent
 
 % Key to start an enumerate at a given number
-\define@key{tcolornumitem}{start}{
-	\setcounter{tcolornumi}{#1}
-	\setcounter{tcolornumistart}{\value{tcolornumi}}
+\define@key{tcolornumitem}{start}{%
+	\setcounter{tcolornumi}{#1}%
+	\setcounter{tcolornumistart}{\value{tcolornumi}}%
 }
 
 % Key to resume an enumerate at previous number
-\define@key{tcolornumitem}{resume}[]{
-	\setcounter{tcolornumistart}{\value{tcolornumi}}
+\define@key{tcolornumitem}{resume}[]{%
+	\setcounter{tcolornumistart}{\value{tcolornumi}}%
 }
 
 \newenvironment{tcolorenumerate}[1][start=1]{% begdef

--- a/src/technumitem.sty
+++ b/src/technumitem.sty
@@ -70,13 +70,12 @@
 
 % SHORT VERSIONS
 \newenvironment{checklistenumerate}[1][start=1]{% begdef
-    \setkeys{checklistnumitem}{#1}
-	\newcommand{\blueitem}[2]{%
-		\item \blue{##1} {##2}%
-        \stepcounter{checklistnumi}%
+    \setkeys{checklistnumitem}{#1}%
+	\newcommand{\blueitem}[1][]{%
+		\item \blue{##1}\stepcounter{checklistnumi}%
 	}
-	\newcommand{\dblueitem}[2]{%
-		\item \dblue{##1} {##2}%
+	\newcommand{\dblueitem}[1][]{%
+		\item \dblue{##1}%
         \stepcounter{checklistnumi}%
 	}
 	\begin{outerchecklistenumerate}[start=\value{checklistnumi}]
@@ -85,11 +84,11 @@
 }
 
 \newenvironment{checklistitemize}{% begdef
-	\newcommand{\blueitem}[2]{%
-		\item \blue{##1} ##2%
+	\newcommand{\blueitem}[1][]{%
+		\item \blue{##1}%
 	}
-	\newcommand{\dblueitem}[2]{%
-		\item \dblue{##1} ##2%
+	\newcommand{\dblueitem}[1][]{%
+		\item \dblue{##1}%
 	}
 	\begin{outerchecklistitemize}
 }{% enddef
@@ -176,47 +175,52 @@
 }
 
 \newenvironment{tcolorenumerate}[1][start=1]{% begdef
-	\setkeys{tcolornumitem}{#1}
-	% Define command equiv to `item`
-	% arg 1 - typeset in blue in 2. column
-	% arg 2 - typeset normally in 3. column
-	\newcommand{\blueitem}[2]{
-        \ifnum\value{tcolornumi}>\value{tcolornumistart}
-            \tcbline
-		\else
-		\fi
-        \begin{innertcolorenumitem}
-		    \textbf{\arabic{tcolornumi}.}\blue{##1}
-            \tcblower
-            ##2
-        \end{innertcolorenumitem}
-		\stepcounter{tcolornumi} \\
-	}
-	% Uses custom tcolorbox style
-	\begin{outertcolorenumitem}
+	\setkeys{tcolornumitem}{#1}%
+    \def\endpreviousitem{%
+        \ifx\tempitem\undefined\else\end{innertcolorenumitem}\fi%
+    }%
+    \def\seppreviousitem{%
+        \ifx\tempitem\undefined\else\tcbline\fi%
+        \global\let\tempitem\undefined%
+    }%
+	\newcommand{\blueitem}[1][]{%
+        \endpreviousitem% Close the previous item, if any
+        \seppreviousitem% Separate from previous item, if any
+        \begin{innertcolorenumitem}%
+		    \textbf{\arabic{tcolornumi}.}\ \ifx\relax##1\relax\else\blue{##1}\fi% Only use the optional argument if it is provided
+            \tcblower%
+            \global\let\tempitem\relax%
+		    \stepcounter{tcolornumi}
+	}%
+    \global\let\tempitem\undefined%
+	\begin{outertcolorenumitem}% Uses custom tcolorbox style
 }{% enddef
-	\end{outertcolorenumitem}
+    \endpreviousitem% Ensure the last item is closed
+    \global\let\tempitem\undefined% Reset \tempitem to avoid interference outside the environment
+	\end{outertcolorenumitem}%
 }
 
 \newenvironment{tcoloritemize}[1][start=1]{% begdef
-	\setkeys{tcolornumitem}{#1}
-	% Define command equiv to `item`
-	% arg 1 - typeset in blue in 2. column
-	% arg 2 - typeset normally in 3. column
-	\newcommand{\blueitem}[2]{
-        \ifnum\value{tcolornumi}>\value{tcolornumistart}
-            \tcbline
-		\else
-		\fi
-        \begin{innertcolorenumitem}
-		    \blue{##1}
-            \tcblower
-            ##2
-        \end{innertcolorenumitem}
-		\stepcounter{tcolornumi} \\
-	}
-	% Uses custom tcolorbox style
-	\begin{outertcolorenumitem}
+    \setkeys{tcolornumitem}{#1}%
+    \def\endpreviousitem{%
+        \ifx\tempitem\undefined\else\end{innertcolorenumitem}\fi%
+    }%
+    \def\seppreviousitem{%
+        \ifx\tempitem\undefined\else\tcbline\fi%
+        \global\let\tempitem\undefined%
+    }%
+    \newcommand{\blueitem}[1][]{%
+        \endpreviousitem% Close the previous item, if any
+        \seppreviousitem% Separate from previous item, if any
+        \begin{innertcolorenumitem}%
+            \ifx\relax##1\relax\else\blue{##1}\fi% Only use the optional argument if it is provided
+            \tcblower%
+            \global\let\tempitem\relax
+    }%
+    \global\let\tempitem\undefined%
+    \begin{outertcolorenumitem}% Uses custom tcolorbox style
 }{% enddef
-	\end{outertcolorenumitem}
+    \endpreviousitem% Ensure the last item is closed
+    \global\let\tempitem\undefined% Reset \tempitem to avoid interference outside the environment
+    \end{outertcolorenumitem}%
 }


### PR DESCRIPTION
Rewrite custom `\blueitem` commands to follow enumitem-like syntax. 

Instead of 
```tex
\blueitem{item}{description}
```
now is
```tex
\blueitem[item] description
```